### PR TITLE
feat: merge Потвърди into Изчисли, add interest totals, add EUR/BGN d…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import {
 import { Check, Close, ContentCopy, GitHub, InfoOutlined, LinkedIn, ReceiptLongOutlined } from '@mui/icons-material'
 import { processFile, parseFilesData } from './services/processFile.js'
 import { inferPriorPositions } from './services/inferPriorPositions.js'
+import { getPrevYearDefaultAcqDate } from './domain/fx/fxRates.js'
 import AboutSection from './content/AboutSection.jsx'
 import Disclaimer from './content/Disclaimer.jsx'
 import TermsContent from './content/TermsContent.jsx'
@@ -63,7 +64,7 @@ function TabPanel({ children, value, index }) {
 const TRADE_SUM_COLS     = ['proceeds', 'comm', 'fee', 'totalWithFee']
 const TRADE_SUM_BGN_COLS = ['totalWithFeeBGN', 'costBasisBGN']
 
-function buildTradeTotals(dataRows) {
+function buildTradeTotals(dataRows, localCurrencyCode = 'BGN') {
   const totals = []
   for (const label of ['Облагаем', 'Освободен']) {
     const group = dataRows.filter(r => r.taxExemptLabel === label)
@@ -76,9 +77,9 @@ function buildTradeTotals(dataRows) {
       TRADE_SUM_BGN_COLS.forEach(k => { row[k] = subset.reduce((s, r) => s + (r[k] ?? 0), 0) })
       totals.push(row)
     }
-    const bgnRow = { _total: true, taxExemptLabel: label, currency: 'BGN' }
-    TRADE_SUM_BGN_COLS.forEach(k => { bgnRow[k] = group.reduce((s, r) => s + (r[k] ?? 0), 0) })
-    totals.push(bgnRow)
+    const lclRow = { _total: true, taxExemptLabel: label, currency: localCurrencyCode }
+    TRADE_SUM_BGN_COLS.forEach(k => { lclRow[k] = group.reduce((s, r) => s + (r[k] ?? 0), 0) })
+    totals.push(lclRow)
   }
   return totals
 }
@@ -106,7 +107,9 @@ function buildTaxSummary(dataRows) {
 function ResultTabs({ result, jsonText }) {
   const [tab, setTab] = useState(0)
   const hasDividends = result.dividends.rows.length > 0
-  const hasInterest  = result.interest.rows.length > 0
+  const hasInterest  = result.interest.rows.filter(r => !r._total).length > 0
+
+  const { taxYear, localCurrencyCode, localCurrencyLabel } = result
 
   // Mutable trades data rows (user can toggle taxable status)
   const [tradesDataRows, setTradesDataRows] = useState(() =>
@@ -115,8 +118,8 @@ function ResultTabs({ result, jsonText }) {
 
   const trades = useMemo(() => ({
     columns: result.trades.columns,
-    rows: [...tradesDataRows, ...buildTradeTotals(tradesDataRows)],
-  }), [result.trades.columns, tradesDataRows])
+    rows: [...tradesDataRows, ...buildTradeTotals(tradesDataRows, localCurrencyCode)],
+  }), [result.trades.columns, tradesDataRows, localCurrencyCode])
 
   const taxSummary = useMemo(() => buildTaxSummary(tradesDataRows), [tradesDataRows])
   const approxRows = useMemo(
@@ -170,27 +173,28 @@ function ResultTabs({ result, jsonText }) {
         {tabs.map((t, i) => <Tab key={i} label={t.label} />)}
       </Tabs>
 
-      {/* Сделки: Trade Confirmation table + Прил. №5 (taxable) + Прил. №13 (EU ETF) */}
+      {/* Сделки */}
       <TabPanel value={tab} index={TAB_TRADES}>
         <DataTable title="Trade Confirmation – Сделки" data={trades} countLabel="сделки" onCheckChange={handleTaxableToggle} />
-        <PriorYearApproxWarning rows={approxRows} />
-        <TaxApp5  summary={taxSummary.app5} />
-        <TaxApp13 summary={taxSummary.app13} />
+        <PriorYearApproxWarning rows={approxRows} taxYear={taxYear} />
+        <TaxApp5  summary={taxSummary.app5}  localCurrencyLabel={localCurrencyLabel} />
+        <TaxApp13 summary={taxSummary.app13} localCurrencyLabel={localCurrencyLabel} />
       </TabPanel>
 
-      {/* Позиции: holdings table + Прил. №8 Part I */}
+      {/* Позиции */}
       <TabPanel value={tab} index={TAB_HOLDINGS}>
         <DataTable title="Open Positions – IBKR" data={result.holdings} countLabel="позиции" />
         <TaxApp8Holdings data={result.taxSummary.app8Holdings} />
       </TabPanel>
 
-      {/* Дивиденти: dividends table + Прил. №8 Part III */}
+      {/* Дивиденти */}
       {hasDividends && (
         <TabPanel value={tab} index={TAB_DIVIDENDS}>
           <TaxApp8Dividends data={result.taxSummary.app8Dividends} />
         </TabPanel>
       )}
 
+      {/* Лихви */}
       {hasInterest && (
         <TabPanel value={tab} index={TAB_INTEREST}>
           <Box sx={{
@@ -210,7 +214,8 @@ function ResultTabs({ result, jsonText }) {
                 Лихвите от IBKR се декларират в <strong>Приложение №6</strong>, Ред 6,{' '}
                 <strong>Код 606</strong>: „Обща сума на доходите с код 606, платците на които не са
                 предприятия или самоосигуряващи се лица". В поле <em>Размер на дохода</em> въведете
-                общата сума в левове (BGN), изчислена по курс на БНБ за датата на всяко плащане.
+                общата сума в {localCurrencyLabel} ({localCurrencyCode}), изчислена по курс на БНБ
+                за датата на всяко плащане.
               </Typography>
             </Box>
           </Box>
@@ -218,7 +223,7 @@ function ResultTabs({ result, jsonText }) {
         </TabPanel>
       )}
 
-      {/* Dev: raw JSON */}
+      {/* Dev */}
       {DEV_MODE && (
         <TabPanel value={tab} index={TAB_DEV}>
           <div className="output">
@@ -267,10 +272,12 @@ export default function App() {
   const [htmlFile, setHtmlFile] = useState(null)
   const [htmlFileUrl, setHtmlFileUrl] = useState('')
 
-  // ── Prior-year positions inference ───────────────────────────
-  // null = not yet parsed; [] = parsed, nothing to confirm; [...] = needs confirmation
-  const [inferredPositions, setInferredPositions]   = useState(null)
-  const [confirmedPositions, setConfirmedPositions] = useState(null)
+  // ── Prior-year positions (controlled form state, lifted here) ────────────
+  // null  = not yet inferred / files not both loaded
+  // []    = inferred, no prior positions found
+  // [...] = editable prior positions (form shown above button row)
+  const [pendingPositions, setPendingPositions] = useState(null)
+  const [taxYear, setTaxYear] = useState(2025)
   const [parsing, setParsing] = useState(false)
 
   // ── Results and UI states ────────────────────────────────────
@@ -295,11 +302,10 @@ export default function App() {
     return () => URL.revokeObjectURL(url)
   }, [htmlFile])
 
-  // ── Preliminary parse: infer prior-year positions when both files ready ─────
+  // ── Preliminary parse: infer prior-year positions when both files ready ──
   useEffect(() => {
     if (!csvFile || !htmlFile) {
-      setInferredPositions(null)
-      setConfirmedPositions(null)
+      setPendingPositions(null)
       return
     }
     let cancelled = false
@@ -307,19 +313,26 @@ export default function App() {
     parseFilesData({ csvFile, htmlFile })
       .then(data => {
         if (cancelled) return
+        const yr = data.taxYear ?? 2025
+        setTaxYear(yr)
         const prior = inferPriorPositions({
           htmlTrades:    data.processedTrades.rows,
           openPositions: data.openPositions.rows,
           csvTradeBasis: data.csvTradeBasis,
+          taxYear:       yr,
         })
-        setInferredPositions(prior)
-        if (prior.length === 0) setConfirmedPositions([])
+        // Convert inferred positions to editable form objects
+        const defaultAcqDate = getPrevYearDefaultAcqDate(yr)
+        setPendingPositions(prior.map(p => ({
+          ...p,
+          costBGNInput:    p.costBGN != null ? String(Number(p.costBGN).toFixed(2)) : '',
+          lastBuyDateInput: p.lastBuyDate ?? defaultAcqDate,
+        })))
       })
       .catch(e => {
         if (cancelled) return
         console.warn('Prior-year inference failed:', e)
-        setInferredPositions([])
-        setConfirmedPositions([])
+        setPendingPositions([])
       })
       .finally(() => { if (!cancelled) setParsing(false) })
     return () => { cancelled = true }
@@ -332,34 +345,39 @@ export default function App() {
     setResult(null)
     setError(null)
   }
-
   function clearCsvFile() {
     setCsvFile(null)
     setResult(null)
     setError(null)
   }
-
   function selectHtmlFile(f) {
     setHtmlFile(f)
     setResult(null)
     setError(null)
   }
-
   function clearHtmlFile() {
     setHtmlFile(null)
     setResult(null)
     setError(null)
   }
 
-
-  // ── Process both files together ──────────────────────────────
+  // ── Calculate ────────────────────────────────────────────────
   async function handleCalculate() {
-    if (!csvFile || !htmlFile || !agreed || confirmedPositions === null) return
+    if (!csvFile || !htmlFile || !agreed || parsing) return
     setError(null)
     setResult(null)
     setLoading(true)
     try {
-      const res = await processFile({ csvFile, htmlFile, priorPositions: confirmedPositions })
+      // Convert form editable objects to processFile format
+      const priorPositions = (pendingPositions ?? []).map(p => ({
+        symbol:      p.symbol,
+        currency:    p.currency,
+        qty:         p.qty,
+        costUSD:     p.costUSD,
+        costBGN:     parseFloat(String(p.costBGNInput).replace(',', '.')) || 0,
+        lastBuyDate: p.lastBuyDateInput || getPrevYearDefaultAcqDate(taxYear),
+      }))
+      const res = await processFile({ csvFile, htmlFile, priorPositions })
       setResult(res)
     } catch (e) {
       setError(e.message)
@@ -375,8 +393,8 @@ export default function App() {
       fetch('/demo/U0_2025_trades_demo.htm'),
     ])
     const [csvText, htmText] = await Promise.all([csvResp.text(), htmResp.text()])
-    selectCsvFile(new File([new Blob([csvText], { type: 'text/csv' })],    'U0_2025_activity_demo.csv',  { type: 'text/csv' }))
-    setHtmlFile(  new File([new Blob([htmText], { type: 'text/html' })],   'U0_2025_trades_demo.htm',   { type: 'text/html' }))
+    selectCsvFile(new File([new Blob([csvText], { type: 'text/csv' })],  'U0_2025_activity_demo.csv', { type: 'text/csv' }))
+    setHtmlFile(  new File([new Blob([htmText], { type: 'text/html' })], 'U0_2025_trades_demo.htm',  { type: 'text/html' }))
   }
 
   async function handleLoadDemo() {
@@ -384,8 +402,7 @@ export default function App() {
     catch (e) { setError('Неуспешно зареждане на демо файл: ' + e.message) }
   }
 
-
- const jsonText = result ? JSON.stringify(result, null, 2) : ''
+  const jsonText = result ? JSON.stringify(result, null, 2) : ''
 
   return (
     <div className="app">
@@ -399,20 +416,14 @@ export default function App() {
       </header>
 
       <div className="app-content">
-
         <main>
-          {/* ── Two dropzones ───────────────────────────────────────────── */}
+          {/* ── Two dropzones ──────────────────────────────────────── */}
           <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 2 }}>
-
-            {/* Activity Statement CSV */}
             <Box>
               <Dropzone
-                file={csvFile}
-                fileUrl={csvFileUrl}
-                onFileSelect={selectCsvFile}
-                onClearFile={clearCsvFile}
-                accept=".csv"
-                label="Activity Statement CSV тук"
+                file={csvFile} fileUrl={csvFileUrl}
+                onFileSelect={selectCsvFile} onClearFile={clearCsvFile}
+                accept=".csv" label="Activity Statement CSV тук"
               />
               <Typography variant="caption" color="text.secondary"
                 sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: -1, mb: 1.5, px: 0.5 }}>
@@ -420,16 +431,11 @@ export default function App() {
                 IBKR Portal → Reports → Statements → Activity (формат CSV)
               </Typography>
             </Box>
-
-            {/* Trade Confirmation HTML */}
             <Box>
               <Dropzone
-                file={htmlFile}
-                fileUrl={htmlFileUrl}
-                onFileSelect={selectHtmlFile}
-                onClearFile={clearHtmlFile}
-                accept=".htm,.html"
-                label="Trade Confirmation HTML тук"
+                file={htmlFile} fileUrl={htmlFileUrl}
+                onFileSelect={selectHtmlFile} onClearFile={clearHtmlFile}
+                accept=".htm,.html" label="Trade Confirmation HTML тук"
                 infoContent={HTM_INFO}
               />
               <Typography variant="caption" color="text.secondary"
@@ -439,56 +445,53 @@ export default function App() {
               </Typography>
             </Box>
           </Box>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mt: 1, flexWrap: 'wrap' }}>
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={agreed}
-                      onChange={e => setAgreed(e.target.checked)}
-                      size="small"
-                      color="primary"
-                    />
-                  }
-                  label={
-                    <Typography variant="body2">
-                      Съгласен/на съм с{' '}
-                      <Link component="button" variant="body2" onClick={() => setShowTerms(true)}
-                        sx={{ verticalAlign: 'baseline' }}>
-                        условията за ползване
-                      </Link>
-                    </Typography>
-                  }
-                />
-                <Button
-                  variant="contained"
-                  disabled={!csvFile || !htmlFile || !agreed || loading || parsing || confirmedPositions === null}
-                  onClick={handleCalculate}
-                >
-                  {loading ? 'Изчислява се...' : 'Изчисли'}
-                </Button>
-                <Button variant="outlined" onClick={handleLoadDemo}>
-                  Зареди демо
-                </Button>
-              </Box>
 
-          {/* Prior-year positions form — shown before first calculation */}
-          {inferredPositions !== null && inferredPositions.length > 0 && confirmedPositions === null && (
+          {/* ── Prior-year positions form (above button row) ────────── */}
+          {pendingPositions !== null && pendingPositions.length > 0 && (
             <PriorYearPositionsForm
-              positions={inferredPositions}
-              onConfirm={setConfirmedPositions}
+              positions={pendingPositions}
+              onPositionChange={(i, field, value) =>
+                setPendingPositions(prev => prev.map((p, idx) => idx === i ? { ...p, [field]: value } : p))
+              }
+              taxYear={taxYear}
             />
           )}
-          {inferredPositions !== null && inferredPositions.length > 0 && confirmedPositions !== null && !result && (
-            <Alert severity="success" sx={{ mt: 2 }}>
-              Потвърдени {confirmedPositions.length} позиции от предходна година. Натиснете <strong>Изчисли</strong>.
-            </Alert>
-          )}
 
-          {error && (
-            <Alert severity="error" sx={{ mt: 2 }}>{error}</Alert>
-          )}
+          {/* ── Checkbox + Изчисли + демо ────────────────────────────── */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mt: 1, flexWrap: 'wrap' }}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={agreed}
+                  onChange={e => setAgreed(e.target.checked)}
+                  size="small"
+                  color="primary"
+                />
+              }
+              label={
+                <Typography variant="body2">
+                  Съгласен/на съм с{' '}
+                  <Link component="button" variant="body2" onClick={() => setShowTerms(true)}
+                    sx={{ verticalAlign: 'baseline' }}>
+                    условията за ползване
+                  </Link>
+                </Typography>
+              }
+            />
+            <Button
+              variant="contained"
+              disabled={!csvFile || !htmlFile || !agreed || loading || parsing}
+              onClick={handleCalculate}
+            >
+              {loading ? 'Изчислява се...' : parsing ? 'Зарежда се...' : 'Изчисли'}
+            </Button>
+            <Button variant="outlined" onClick={handleLoadDemo}>
+              Зареди демо
+            </Button>
+          </Box>
 
-          {/* Activity Statement result */}
+          {error && <Alert severity="error" sx={{ mt: 2 }}>{error}</Alert>}
+
           {result && (
             <>
               <Disclaimer />

--- a/src/components/PriorYearApproxWarning.jsx
+++ b/src/components/PriorYearApproxWarning.jsx
@@ -1,6 +1,8 @@
 import { Box, Typography } from '@mui/material'
 import { WarningAmberOutlined } from '@mui/icons-material'
-import { PREV_YEAR_END_DATE, findUsdRate } from '../domain/fx/fxRates.js'
+import {
+  findUsdRate, getPrevYearEndDate, getLocalCurrencyLabel,
+} from '../domain/fx/fxRates.js'
 
 function fmtNum(n, decimals = 2) {
   return Number(n).toLocaleString('bg-BG', {
@@ -9,19 +11,19 @@ function fmtNum(n, decimals = 2) {
   })
 }
 
-const PREV_RATE_USD = findUsdRate(PREV_YEAR_END_DATE)
-
 function fmtDate(dateStr) {
-  // 'YYYY-MM-DD' → 'DD.MM.YYYY'
   if (!dateStr) return dateStr
   const [y, m, d] = dateStr.split('-')
   return `${d}.${m}.${y}`
 }
 
-export default function PriorYearApproxWarning({ rows }) {
+export default function PriorYearApproxWarning({ rows, taxYear = 2025 }) {
   if (!rows || rows.length === 0) return null
 
-  const prevYearLabel = PREV_YEAR_END_DATE.slice(0, 4)  // '2024'
+  const lcl             = getLocalCurrencyLabel(taxYear)
+  const prevYearEndDate = getPrevYearEndDate(taxYear)
+  const prevRate        = findUsdRate(prevYearEndDate)
+  const prevYearLabel   = String(taxYear - 1)
 
   return (
     <Box sx={{
@@ -36,13 +38,13 @@ export default function PriorYearApproxWarning({ rows }) {
         <WarningAmberOutlined sx={{ color: 'warning.main', mt: 0.15, flexShrink: 0 }} />
         <Box>
           <Typography variant="subtitle2" fontWeight={700} color="warning.dark" gutterBottom>
-            Приблизителна цена на придобиване в лева — позиции от предходна година
+            Приблизителна цена на придобиване в {lcl} — позиции от предходна година
           </Typography>
           <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.7, display: 'block' }}>
             За посочените по-долу сделки не са открити данни за покупка в текущата отчетна година.
-            Цената на придобиване в лева е изчислена по фиксирания курс на БНБ към края на {prevYearLabel} г.
-            ({fmtDate(PREV_YEAR_END_DATE)}
-            {PREV_RATE_USD != null ? ` — 1 USD = ${fmtNum(PREV_RATE_USD, 4)} лв` : ''}).
+            Цената на придобиване в {lcl} е изчислена по курса на БНБ към края на {prevYearLabel} г.
+            ({fmtDate(prevYearEndDate)}
+            {prevRate != null ? ` — 1 USD = ${fmtNum(prevRate, 4)} ${lcl}` : ''}).
             {' '}Действителната стойност може да се различава, ако акциите са придобити при различен курс
             в рамките на {prevYearLabel} г. Препоръчваме да проверите точния курс на придобиване
             в историята на сделките си и при необходимост да коригирате стойността ръчно.
@@ -63,7 +65,7 @@ export default function PriorYearApproxWarning({ rows }) {
                   {' · цена на придобиване: '}
                   <strong>{fmtNum(r.costBasis, 2)} {r.currency}</strong>
                   {r.costBasisBGN != null && (
-                    <> {' ≈ '}<strong>{fmtNum(r.costBasisBGN, 2)} лв</strong> <em>(приблизително)</em></>
+                    <> {' ≈ '}<strong>{fmtNum(r.costBasisBGN, 2)} {lcl}</strong> <em>(приблизително)</em></>
                   )}
                 </>
               )}

--- a/src/components/PriorYearPositionsForm.jsx
+++ b/src/components/PriorYearPositionsForm.jsx
@@ -1,12 +1,11 @@
-import { useState } from 'react'
 import {
-  Box, Button, Paper, Table, TableBody, TableCell, TableContainer,
+  Box, Paper, Table, TableBody, TableCell, TableContainer,
   TableHead, TableRow, TextField, Typography,
 } from '@mui/material'
 import { InfoOutlined } from '@mui/icons-material'
-import { PREV_YEAR_END_DATE, PREV_YEAR_DEFAULT_ACQ_DATE, findUsdRate } from '../domain/fx/fxRates.js'
-
-const PREV_RATE_USD = findUsdRate(PREV_YEAR_END_DATE)
+import {
+  findUsdRate, getPrevYearEndDate, getLocalCurrencyLabel,
+} from '../domain/fx/fxRates.js'
 
 function fmtNum(n, decimals = 2) {
   if (n == null) return '—'
@@ -23,39 +22,22 @@ function fmtDate(dateStr) {
 }
 
 /**
- * Form shown after both files are loaded, before the user can click Изчисли.
- * Lets the user review and correct the inferred prior-year cost basis in BGN
- * and the default acquisition date for each prior-year position.
+ * Controlled form showing inferred prior-year positions.
+ * No confirm button — Изчисли (in App) reads the current values directly.
+ *
+ * Props:
+ *   positions       – array of editable position objects (from App.jsx state)
+ *   onPositionChange(i, field, value) – called on every edit
+ *   taxYear         – current tax year (determines currency label and prev-year date)
  */
-export default function PriorYearPositionsForm({ positions, onConfirm }) {
-  const [edited, setEdited] = useState(() =>
-    positions.map(p => ({
-      ...p,
-      costBGNInput: p.costBGN != null ? String(Number(p.costBGN).toFixed(2)) : '',
-      lastBuyDateInput: p.lastBuyDate ?? PREV_YEAR_DEFAULT_ACQ_DATE,
-    }))
-  )
-
-  function handleChange(i, field, value) {
-    setEdited(prev => prev.map((p, idx) => idx === i ? { ...p, [field]: value } : p))
-  }
-
-  function handleConfirm() {
-    const confirmed = edited.map(p => ({
-      symbol:      p.symbol,
-      currency:    p.currency,
-      qty:         p.qty,
-      costUSD:     p.costUSD,
-      costBGN:     parseFloat(p.costBGNInput.replace(',', '.')) || 0,
-      lastBuyDate: p.lastBuyDateInput || PREV_YEAR_DEFAULT_ACQ_DATE,
-    }))
-    onConfirm(confirmed)
-  }
-
-  const prevYearLabel = PREV_YEAR_END_DATE.slice(0, 4)
+export default function PriorYearPositionsForm({ positions, onPositionChange, taxYear = 2025 }) {
+  const lcl             = getLocalCurrencyLabel(taxYear)
+  const prevYearEndDate = getPrevYearEndDate(taxYear)
+  const prevRate        = findUsdRate(prevYearEndDate)
+  const prevYearLabel   = String(taxYear - 1)
 
   return (
-    <Box sx={{ mt: 2, mb: 2 }}>
+    <Box sx={{ mt: 2, mb: 1 }}>
       <Paper variant="outlined" sx={{ borderRadius: 2, overflow: 'hidden' }}>
         {/* Header */}
         <Box sx={{
@@ -67,16 +49,15 @@ export default function PriorYearPositionsForm({ positions, onConfirm }) {
           <InfoOutlined sx={{ color: 'warning.main', mt: 0.15, flexShrink: 0 }} />
           <Box>
             <Typography variant="subtitle2" fontWeight={700} color="warning.dark" gutterBottom>
-              Потвърдете позициите от предходна година ({prevYearLabel})
+              Позиции от предходна година ({prevYearLabel}) — прегледайте и коригирайте при нужда
             </Typography>
             <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.7, display: 'block' }}>
               Установени са позиции, придобити преди текущата данъчна година.
-              Цената на придобиване в лева е изчислена по курса на БНБ към края на {prevYearLabel}&nbsp;г.
-              ({fmtDate(PREV_YEAR_END_DATE)}
-              {PREV_RATE_USD != null ? ` — 1&nbsp;USD&nbsp;=&nbsp;${fmtNum(PREV_RATE_USD, 4)}&nbsp;лв` : ''}).
-              {' '}Можете да коригирате стойностите спрямо действителния курс на придобиване и да
-              промените датата на последна покупка.
-              {' '}След натискане на <strong>Потвърди</strong> бутонът <strong>Изчисли</strong> ще се активира.
+              Цената на придобиване в {lcl} е изчислена по курса на БНБ към края на {prevYearLabel}&nbsp;г.
+              ({fmtDate(prevYearEndDate)}
+              {prevRate != null ? ` — 1\u00a0USD\u00a0=\u00a0${fmtNum(prevRate, 4)}\u00a0${lcl}` : ''}).
+              {' '}Можете да коригирате стойностите спрямо действителния курс на придобиване и
+              датата на последна покупка, след което натиснете <strong>Изчисли</strong>.
             </Typography>
           </Box>
         </Box>
@@ -90,12 +71,12 @@ export default function PriorYearPositionsForm({ positions, onConfirm }) {
                 <TableCell sx={{ fontWeight: 700 }}>Валута</TableCell>
                 <TableCell align="right" sx={{ fontWeight: 700 }}>Брой</TableCell>
                 <TableCell align="right" sx={{ fontWeight: 700 }}>Цена придобиване (вал)</TableCell>
-                <TableCell align="right" sx={{ fontWeight: 700, minWidth: 160 }}>Цена придобиване (лв)</TableCell>
+                <TableCell align="right" sx={{ fontWeight: 700, minWidth: 160 }}>Цена придобиване ({lcl})</TableCell>
                 <TableCell sx={{ fontWeight: 700, minWidth: 140 }}>Дата последна покупка</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
-              {edited.map((p, i) => (
+              {positions.map((p, i) => (
                 <TableRow key={p.symbol} hover>
                   <TableCell sx={{ fontWeight: 700 }}>{p.symbol}</TableCell>
                   <TableCell>{p.currency}</TableCell>
@@ -111,7 +92,7 @@ export default function PriorYearPositionsForm({ positions, onConfirm }) {
                       variant="standard"
                       inputProps={{ style: { textAlign: 'right', fontFamily: 'monospace', width: 120 } }}
                       value={p.costBGNInput}
-                      onChange={e => handleChange(i, 'costBGNInput', e.target.value)}
+                      onChange={e => onPositionChange(i, 'costBGNInput', e.target.value)}
                     />
                   </TableCell>
                   <TableCell>
@@ -121,7 +102,7 @@ export default function PriorYearPositionsForm({ positions, onConfirm }) {
                       type="date"
                       inputProps={{ style: { fontFamily: 'monospace' } }}
                       value={p.lastBuyDateInput}
-                      onChange={e => handleChange(i, 'lastBuyDateInput', e.target.value)}
+                      onChange={e => onPositionChange(i, 'lastBuyDateInput', e.target.value)}
                     />
                   </TableCell>
                 </TableRow>
@@ -129,13 +110,6 @@ export default function PriorYearPositionsForm({ positions, onConfirm }) {
             </TableBody>
           </Table>
         </TableContainer>
-
-        {/* Confirm button */}
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', px: 2, py: 1.5, borderTop: '1px solid', borderColor: 'divider' }}>
-          <Button variant="contained" color="warning" onClick={handleConfirm}>
-            Потвърди
-          </Button>
-        </Box>
       </Paper>
     </Box>
   )

--- a/src/components/TaxApp13.jsx
+++ b/src/components/TaxApp13.jsx
@@ -1,16 +1,17 @@
 import { TaxFormSection, TaxRow } from './TaxFormSection.jsx'
 import { fmt } from '../utils/fmt.js'
 
-export default function TaxApp13({ summary }) {
+export default function TaxApp13({ summary, localCurrencyLabel = 'лв' }) {
   if (!summary || summary.totalProceedsBGN === 0) return null
+  const lcl = localCurrencyLabel
   return (
     <TaxFormSection
       title="Приложение №13 – Част II"
       subtitle="Необлагаеми доходи от продажба на дялове от ETF на регулирани пазари в ЕС"
     >
       <TaxRow label="Код" value="508" />
-      <TaxRow label="Брутен размер на дохода (продажни цени) (лв)" value={fmt(summary.totalProceedsBGN)} />
-      <TaxRow label="Цена на придобиване (лв)"                      value={fmt(summary.totalCostBasisBGN)} />
+      <TaxRow label={`Брутен размер на дохода (продажни цени) (${lcl})`} value={fmt(summary.totalProceedsBGN)} />
+      <TaxRow label={`Цена на придобиване (${lcl})`}                      value={fmt(summary.totalCostBasisBGN)} />
     </TaxFormSection>
   )
 }

--- a/src/components/TaxApp5.jsx
+++ b/src/components/TaxApp5.jsx
@@ -3,8 +3,9 @@ import { InfoOutlined } from '@mui/icons-material'
 import { TaxFormSection, TaxRow } from './TaxFormSection.jsx'
 import { fmt } from '../utils/fmt.js'
 
-export default function TaxApp5({ summary }) {
+export default function TaxApp5({ summary, localCurrencyLabel = 'лв' }) {
   if (!summary) return null
+  const lcl = localCurrencyLabel
   const netTaxable = summary.profits - summary.losses
   const taxDue     = Math.max(netTaxable, 0) * 0.10
   return (
@@ -13,17 +14,17 @@ export default function TaxApp5({ summary }) {
       subtitle="Доходи от прехвърляне на финансови активи (акции, ETF извън ЕС и др.)"
     >
       <TaxRow label="Код" value="508" />
-      <TaxRow label="Общ размер на продажните цени при продажба или замяна на финансови активи (лв)"
+      <TaxRow label={`Общ размер на продажните цени при продажба или замяна на финансови активи (${lcl})`}
         value={fmt(summary.totalProceedsBGN)} />
-      <TaxRow label="Общ размер на цените на придобиване (лв)"
+      <TaxRow label={`Общ размер на цените на придобиване (${lcl})`}
         value={fmt(summary.totalCostBasisBGN)} />
-      <TaxRow label="Реализирани печалби (лв)"
+      <TaxRow label={`Реализирани печалби (${lcl})`}
         value={fmt(summary.profits)} color="success.main" />
-      <TaxRow label="Реализирани загуби (лв)"
+      <TaxRow label={`Реализирани загуби (${lcl})`}
         value={fmt(summary.losses)} color="error.main" />
-      <TaxRow label="Нетен облагаем доход (печалби − загуби) (лв)"
+      <TaxRow label={`Нетен облагаем доход (печалби − загуби) (${lcl})`}
         value={fmt(netTaxable)} color={netTaxable >= 0 ? 'success.main' : 'error.main'} />
-      <TaxRow label="Дължим данък 10% (лв)"
+      <TaxRow label={`Дължим данък 10% (${lcl})`}
         value={fmt(taxDue)} color="warning.dark" />
       <Box sx={{ display: 'flex', gap: 1, mt: 1.5, p: 1.5, bgcolor: '#EFF6FF', borderRadius: 1.5 }}>
         <InfoOutlined sx={{ fontSize: 15, color: 'primary.main', mt: 0.15, flexShrink: 0 }} />

--- a/src/domain/fx/fxRates.js
+++ b/src/domain/fx/fxRates.js
@@ -1,18 +1,25 @@
 import Decimal from 'decimal.js'
 import rates2024 from './rates/2024.json'
 import rates2025 from './rates/2025.json'
+import rates2026 from './rates/2026.json'
 
-const EUR_BGN = new Decimal('1.95583')  // fixed peg
+export const EUR_BGN = new Decimal('1.95583')  // fixed peg
 
-// Build lookup: 'YYYY-MM-DD' → Decimal rate (merges all available years)
+// Unified rate map: 'YYYY-MM-DD' → Decimal USD/BGN.
+// 2024/2025 files hold USD/BGN directly.
+// 2026 file holds USD/EUR; normalised by × EUR_BGN so the map is always USD/BGN.
 const rateMap = new Map()
 for (const { date, rate } of [...rates2024, ...rates2025]) {
   const [d, m, y] = date.split('.')
   rateMap.set(`${y}-${m}-${d}`, new Decimal(String(rate)))
 }
+for (const { date, rate } of rates2026) {
+  const [d, m, y] = date.split('.')
+  rateMap.set(`${y}-${m}-${d}`, new Decimal(String(rate)).times(EUR_BGN))
+}
 const sortedDates = [...rateMap.keys()].sort()
 
-/** Returns the BNB USD/BGN Decimal rate for the nearest previous trading day. */
+/** Returns the USD/BGN Decimal rate for the nearest previous trading day. */
 export function findUsdRate(dateStr) {
   if (rateMap.has(dateStr)) return rateMap.get(dateStr)
   if (dateStr < sortedDates[0]) return null
@@ -26,7 +33,7 @@ export function findUsdRate(dateStr) {
 }
 
 /**
- * Convert amount to BGN using the BNB rate for dateStr.
+ * Convert amount to BGN.
  * Accepts number, string, or Decimal; returns Decimal or null.
  */
 export function toBGN(amount, currency, dateStr) {
@@ -40,14 +47,36 @@ export function toBGN(amount, currency, dateStr) {
   return null
 }
 
-/** Last trading day of the current tax year (for year-end BGN conversions). */
-export const YEAR_END_DATE = '2025-12-30'
-
-/** Last trading day of the previous year (for rate lookups). */
-export const PREV_YEAR_END_DATE = '2024-12-30'
-
 /**
- * Default acquisition date for prior-year positions where the exact
- * purchase date is unknown — 31 December of the previous year.
+ * Convert amount to the local reporting currency for taxYear.
+ *   2025 → BGN  (same as toBGN)
+ *   2026+ → EUR (EUR passes through; USD uses USD/BGN ÷ EUR_BGN)
+ *
+ * findUsdRate always returns USD/BGN, so USD→EUR = rate ÷ EUR_BGN.
  */
-export const PREV_YEAR_DEFAULT_ACQ_DATE = '2024-12-31'
+export function toLocalCurrency(amount, currency, dateStr, taxYear) {
+  if (amount == null || !currency) return null
+  const d = amount instanceof Decimal ? amount : new Decimal(String(amount))
+  if (taxYear >= 2026) {
+    if (currency === 'EUR') return d
+    if (currency === 'USD') {
+      const usdBgn = findUsdRate(dateStr)
+      return usdBgn != null ? d.times(usdBgn).div(EUR_BGN) : null
+    }
+    return null
+  }
+  return toBGN(amount, currency, dateStr)
+}
+
+// ── Tax-year helpers ──────────────────────────────────────────────────────────
+
+export function getLocalCurrencyCode(taxYear)      { return taxYear >= 2026 ? 'EUR' : 'BGN' }
+export function getLocalCurrencyLabel(taxYear)     { return taxYear >= 2026 ? 'евро' : 'лв' }
+export function getYearEndDate(taxYear)            { return `${taxYear}-12-30` }
+export function getPrevYearEndDate(taxYear)        { return `${taxYear - 1}-12-30` }
+export function getPrevYearDefaultAcqDate(taxYear) { return `${taxYear - 1}-12-31` }
+
+// ── Legacy 2025 constants ─────────────────────────────────────────────────────
+export const YEAR_END_DATE              = getYearEndDate(2025)
+export const PREV_YEAR_END_DATE         = getPrevYearEndDate(2025)
+export const PREV_YEAR_DEFAULT_ACQ_DATE = getPrevYearDefaultAcqDate(2025)

--- a/src/domain/parser/parseTaxYear.js
+++ b/src/domain/parser/parseTaxYear.js
@@ -1,0 +1,20 @@
+/**
+ * Extracts the tax year from the IBKR Activity Statement CSV rows.
+ * Looks for: Statement,Data,Period,"January 1, 2025 - December 31, 2025"
+ *
+ * Throws a Bulgarian-language error for unsupported years (before 2025).
+ */
+export function parseTaxYear(rows) {
+  const row = rows.find(r => r[0] === 'Statement' && r[1] === 'Data' && r[2] === 'Period')
+  if (!row) throw new Error('Не е намерен период на отчета в Statement секцията.')
+  const period = (row[3] || '').trim()
+  const m = period.match(/(\d{4})\s*$/)
+  if (!m) throw new Error(`Неразпознат формат на период: ${period}`)
+  const year = parseInt(m[1])
+  if (year < 2025) {
+    throw new Error(
+      `Годината ${year} не се поддържа. Приложението поддържа отчети от 2025 г. насам.`
+    )
+  }
+  return year
+}

--- a/src/services/inferPriorPositions.js
+++ b/src/services/inferPriorPositions.js
@@ -1,5 +1,7 @@
 import Decimal from 'decimal.js'
-import { toBGN, PREV_YEAR_END_DATE, PREV_YEAR_DEFAULT_ACQ_DATE } from '../domain/fx/fxRates.js'
+import {
+  toLocalCurrency, getPrevYearEndDate, getPrevYearDefaultAcqDate,
+} from '../domain/fx/fxRates.js'
 
 const D0 = new Decimal(0)
 
@@ -25,7 +27,9 @@ function toD(v) {
  *
  * @returns {Array<{ symbol, currency, qty, costUSD, costBGN, lastBuyDate }>}
  */
-export function inferPriorPositions({ htmlTrades, openPositions, csvTradeBasis }) {
+export function inferPriorPositions({ htmlTrades, openPositions, csvTradeBasis, taxYear = 2025 }) {
+  const prevYearEndDate       = getPrevYearEndDate(taxYear)
+  const prevYearDefaultAcqDate = getPrevYearDefaultAcqDate(taxYear)
   // Aggregate per-symbol: qty bought/sold, cost of buys (positive), basis of sells (positive)
   const bySymbol = {}
 
@@ -83,7 +87,7 @@ export function inferPriorPositions({ htmlTrades, openPositions, csvTradeBasis }
     if (priorQtyD.lte(0)) continue  // all shares were bought in current year
 
     const priorCostD   = openCostD.plus(sym.sellBasisUSD).minus(sym.buyCostUSD)
-    const priorCostBGN = toBGN(priorCostD, h.currency, PREV_YEAR_END_DATE)
+    const priorCostBGN = toLocalCurrency(priorCostD, h.currency, prevYearEndDate, taxYear)
 
     result.push({
       symbol:      h.symbol,
@@ -91,7 +95,7 @@ export function inferPriorPositions({ htmlTrades, openPositions, csvTradeBasis }
       qty:         priorQtyD.toNumber(),
       costUSD:     priorCostD.toNumber(),
       costBGN:     priorCostBGN ? priorCostBGN.toNumber() : null,
-      lastBuyDate: PREV_YEAR_DEFAULT_ACQ_DATE,
+      lastBuyDate: prevYearDefaultAcqDate,
     })
   }
 
@@ -114,7 +118,7 @@ export function inferPriorPositions({ htmlTrades, openPositions, csvTradeBasis }
       qty:         priorQtyD.toNumber(),
       costUSD:     priorCostD.toNumber(),
       costBGN:     priorCostBGN ? priorCostBGN.toNumber() : null,
-      lastBuyDate: PREV_YEAR_DEFAULT_ACQ_DATE,
+      lastBuyDate: prevYearDefaultAcqDate,
     })
   }
 

--- a/src/services/processFile.js
+++ b/src/services/processFile.js
@@ -5,7 +5,12 @@ import { parseFinancialInstrumentInfo } from '../domain/parser/parseFinancialIns
 import { parseDividends } from '../domain/parser/parseDividends.js'
 import { parseInterest } from '../domain/parser/parseInterest.js'
 import { parseCsvTradeBasis } from '../domain/parser/parseCsvTrades.js'
-import { toBGN, YEAR_END_DATE, PREV_YEAR_END_DATE, PREV_YEAR_DEFAULT_ACQ_DATE } from '../domain/fx/fxRates.js'
+import { parseTaxYear } from '../domain/parser/parseTaxYear.js'
+import {
+  toLocalCurrency, toBGN,
+  getLocalCurrencyCode, getLocalCurrencyLabel,
+  getYearEndDate, getPrevYearEndDate,
+} from '../domain/fx/fxRates.js'
 import { processHtmlFile } from './processHtmlFile.js'
 import { IBKR_EXCHANGES } from '../domain/constants.js'
 import { EU_COUNTRY_CODES } from '../domain/constants.js'
@@ -36,37 +41,44 @@ function summarizeSells(sells) {
 }
 
 /**
- * Parse both uploaded files into raw data structures without running any
- * tax calculations. Used for the preliminary parse that infers prior-year
- * positions before the user confirms them.
+ * Parse both uploaded files without running tax calculations.
+ * Used for the preliminary parse that infers prior-year positions.
  */
 export async function parseFilesData({ csvFile, htmlFile }) {
   const [processedTrades, text] = await Promise.all([
     processHtmlFile(htmlFile),
     csvFile.text(),
   ])
-  const rows = parseCSV(text)
+  const rows            = parseCSV(text)
+  const taxYear         = parseTaxYear(rows)
   const instrumentInfo  = parseFinancialInstrumentInfo(rows)
   const csvTradeBasis   = parseCsvTradeBasis(rows)
-
-  // Parse open positions without any calculated override yet
   const openPositions   = parseOpenPositions(rows, instrumentInfo, {})
 
-  return { processedTrades, rows, instrumentInfo, csvTradeBasis, openPositions }
+  return { processedTrades, rows, instrumentInfo, csvTradeBasis, openPositions, taxYear }
 }
 
 /**
  * Full tax calculation.
  *
- * @param {{ csvFile, htmlFile }} files
- * @param {Array|null} priorPositions  Confirmed prior-year positions from the
- *   PriorYearPositionsForm.  Each entry: { symbol, currency, qty, costUSD,
- *   costBGN, lastBuyDate }
+ * @param {{ csvFile, htmlFile, priorPositions? }} param0
+ *   priorPositions – confirmed prior-year positions from PriorYearPositionsForm.
+ *   Each entry: { symbol, currency, qty, costUSD, costBGN, lastBuyDate }
  */
 export async function processFile({ csvFile, htmlFile, priorPositions = [] }) {
   const processedTrades = await processHtmlFile(htmlFile)
   const text = await csvFile.text()
   const rows = parseCSV(text)
+
+  const taxYear            = parseTaxYear(rows)
+  const localCurrencyCode  = getLocalCurrencyCode(taxYear)
+  const localCurrencyLabel = getLocalCurrencyLabel(taxYear)
+  const lcl                = localCurrencyLabel   // short alias for column labels
+  const yearEndDate        = getYearEndDate(taxYear)
+  const prevYearEndDate    = getPrevYearEndDate(taxYear)
+
+  const toLcl = (amount, currency, dateStr) =>
+    toLocalCurrency(amount, currency, dateStr, taxYear)
 
   const instrumentInfo = parseFinancialInstrumentInfo(rows)
   const dividends      = parseDividends(rows, instrumentInfo)
@@ -100,18 +112,16 @@ export async function processFile({ csvFile, htmlFile, priorPositions = [] }) {
 
     const exempt = t.type === 'SELL' && isTaxExempt(t, instrumentInfo)
 
-    // All three source values are Decimal from the HTML parser
     const proceedsD = t.proceeds instanceof Decimal ? t.proceeds : new Decimal(String(t.proceeds ?? 0))
     const commD     = t.comm    instanceof Decimal ? t.comm    : new Decimal(String(t.comm    ?? 0))
     const feeD      = t.fee     instanceof Decimal ? t.fee     : new Decimal(String(t.fee     ?? 0))
 
     const totalWithFeeD    = proceedsD.plus(commD).plus(feeD)
-    const totalWithFeeBGND = toBGN(totalWithFeeD, t.currency, t.date)
+    const totalWithFeeBGND = toLcl(totalWithFeeD, t.currency, t.date)
+    const rateD            = toLcl(new Decimal(1), t.currency, t.date)
 
-    const rateD = toBGN(new Decimal(1), t.currency, t.date)
-
-    let costBasis    = null
-    let costBasisBGN = null
+    let costBasis          = null
+    let costBasisBGN       = null
     let costBasisBGNApprox = false
 
     if (t.type === 'BUY') {
@@ -122,20 +132,18 @@ export async function processFile({ csvFile, htmlFile, priorPositions = [] }) {
 
     if (t.type === 'SELL') {
       if (pos.qty.isZero()) {
-        // No BUY in current dataset (and no prior-year seed for this symbol).
-        // Fall back to IBKR's CSV Basis + previous year-end rate.
-        const csvKey = `${t.symbol}|${t.date}|${(t.quantity instanceof Decimal ? t.quantity : new Decimal(String(t.quantity))).toFixed(0)}`
+        // No BUY in current dataset — fall back to IBKR CSV Basis + prev year-end rate.
+        const qtyD  = t.quantity instanceof Decimal ? t.quantity : new Decimal(String(t.quantity))
+        const csvKey = `${t.symbol}|${t.date}|${qtyD.toFixed(0)}`
         const csvBasisD = csvTradeBasis.get(csvKey)
         if (csvBasisD) {
-          const bgnD = toBGN(csvBasisD, t.currency, PREV_YEAR_END_DATE)
-          costBasis    = csvBasisD.toNumber()
-          costBasisBGN = bgnD ? bgnD.toNumber() : null
+          const bgnD = toLcl(csvBasisD, t.currency, prevYearEndDate)
+          costBasis          = csvBasisD.toNumber()
+          costBasisBGN       = bgnD ? bgnD.toNumber() : null
           costBasisBGNApprox = true
         }
       } else {
-        // Normal path: weighted-average cost from accumulated BUYs (and any
-        // prior-year seed), preserving the historical BGN rates.
-        const qtyD      = t.quantity instanceof Decimal ? t.quantity : new Decimal(String(t.quantity))
+        const qtyD       = t.quantity instanceof Decimal ? t.quantity : new Decimal(String(t.quantity))
         const avgCost    = pos.cost.div(pos.qty)
         const avgCostBGN = pos.costBGN.div(pos.qty)
         const cbD        = avgCost.times(qtyD)
@@ -150,20 +158,18 @@ export async function processFile({ csvFile, htmlFile, priorPositions = [] }) {
       }
     }
 
-    const taxable = t.type !== 'SELL' ? null : exempt ? false : true
-
+    const taxable       = t.type !== 'SELL' ? null : exempt ? false : true
     const proceedsBGN   = t.type === 'SELL' && totalWithFeeBGND ? totalWithFeeBGND.toNumber() : null
     const realizedPLBGN = proceedsBGN != null && costBasisBGN != null
-      ? new Decimal(proceedsBGN).minus(costBasisBGN).toNumber()
-      : null
+      ? new Decimal(proceedsBGN).minus(costBasisBGN).toNumber() : null
 
     acc.rows.push({
       ...t,
       '#': i + 1,
       taxable,
       taxExemptLabel: t.type !== 'SELL' ? '' : exempt ? 'Освободен' : 'Облагаем',
-      rate:           rateD ? rateD.toNumber() : null,
-      totalWithFee:   totalWithFeeD.toNumber(),
+      rate:            rateD ? rateD.toNumber() : null,
+      totalWithFee:    totalWithFeeD.toNumber(),
       totalWithFeeBGN: totalWithFeeBGND ? totalWithFeeBGND.toNumber() : null,
       costBasis,
       costBasisBGN,
@@ -173,13 +179,10 @@ export async function processFile({ csvFile, htmlFile, priorPositions = [] }) {
     })
 
     return acc
-  }, {
-    positions: initialPositions,
-    rows: [],
-  })
+  }, { positions: initialPositions, rows: [] })
 
-  const enrichedRows        = result.rows
-  const positionsCostBasis  = {}
+  const enrichedRows       = result.rows
+  const positionsCostBasis = {}
   for (const [sym, pos] of Object.entries(result.positions)) {
     positionsCostBasis[sym] = {
       cost:    pos.cost.toNumber(),
@@ -190,7 +193,7 @@ export async function processFile({ csvFile, htmlFile, priorPositions = [] }) {
   console.info('Open positions:', positionsCostBasis)
   const holdings = parseOpenPositions(rows, instrumentInfo, positionsCostBasis)
 
-  // ── Totals rows ──────────────────────────────────────────────────────────
+  // ── Trade totals rows ────────────────────────────────────────────────────
   const sumCols    = ['proceeds', 'comm', 'fee', 'totalWithFee']
   const sumBgnCols = ['totalWithFeeBGN']
   const dataRows   = [...enrichedRows]
@@ -204,7 +207,7 @@ export async function processFile({ csvFile, htmlFile, priorPositions = [] }) {
     enrichedRows.push(row)
   })
   {
-    const row = { _total: true, currency: 'BGN' }
+    const row = { _total: true, currency: localCurrencyCode }
     sumBgnCols.forEach(k => { row[k] = dataRows.reduce((s, r) => s + (Number(r[k]) || 0), 0) })
     enrichedRows.push(row)
   }
@@ -219,11 +222,11 @@ export async function processFile({ csvFile, htmlFile, priorPositions = [] }) {
   // ── Column definitions ───────────────────────────────────────────────────
   const numCol    = { key: '#', label: '#', align: 'right', mono: true, decimals: 0 }
   const extraCols = [
-    { key: 'totalWithFee',    label: 'Общо + такси (вал)', align: 'right', mono: true, decimals: 2 },
-    { key: 'rate',            label: 'Курс (лв)',           align: 'right', mono: true, decimals: 5, nullAs: '—' },
-    { key: 'totalWithFeeBGN', label: 'Общо + такси (лв)',   align: 'right', mono: true, decimals: 2, nullAs: '—' },
-    { key: 'costBasis',       label: 'Цена на придобиване (вал)', align: 'right', mono: true, decimals: 2, nullAs: '—' },
-    { key: 'costBasisBGN',    label: 'Цена на придобиване (лв)',  align: 'right', mono: true, decimals: 2, nullAs: '—' },
+    { key: 'totalWithFee',    label: 'Общо + такси (вал)',           align: 'right', mono: true, decimals: 2 },
+    { key: 'rate',            label: `Курс (${lcl})`,                align: 'right', mono: true, decimals: 5, nullAs: '—' },
+    { key: 'totalWithFeeBGN', label: `Общо + такси (${lcl})`,        align: 'right', mono: true, decimals: 2, nullAs: '—' },
+    { key: 'costBasis',       label: 'Цена на придобиване (вал)',     align: 'right', mono: true, decimals: 2, nullAs: '—' },
+    { key: 'costBasisBGN',    label: `Цена на придобиване (${lcl})`, align: 'right', mono: true, decimals: 2, nullAs: '—' },
   ]
 
   const trades = {
@@ -231,25 +234,23 @@ export async function processFile({ csvFile, htmlFile, priorPositions = [] }) {
     rows: enrichedRows,
   }
 
-  // ── Last BUY date per symbol (for App8 holdings declaration) ────────────
+  // ── Last BUY date per symbol ─────────────────────────────────────────────
   const lastBuyDate = {}
-
-  // Seed from confirmed prior-year positions
   for (const p of (priorPositions || [])) {
     if (p.symbol && p.lastBuyDate) lastBuyDate[p.symbol] = p.lastBuyDate
   }
-  // Override with any 2025 buys (later date wins)
   enrichedRows.forEach(t => {
     if (t.type === 'BUY' && (!lastBuyDate[t.symbol] || t.date > lastBuyDate[t.symbol])) {
       lastBuyDate[t.symbol] = t.date
     }
   })
 
-  // ── App8 Part I – holdings for declaration ───────────────────────────────
+  // ── App8 Part I – holdings ───────────────────────────────────────────────
   const netBuyQty = {}
   enrichedRows.forEach(t => {
-    if (t.type === 'BUY')  netBuyQty[t.symbol] = (netBuyQty[t.symbol] ?? 0) + (t.quantity instanceof Decimal ? t.quantity.toNumber() : Number(t.quantity))
-    if (t.type === 'SELL') netBuyQty[t.symbol] = (netBuyQty[t.symbol] ?? 0) - (t.quantity instanceof Decimal ? t.quantity.toNumber() : Number(t.quantity))
+    const q = t.quantity instanceof Decimal ? t.quantity.toNumber() : Number(t.quantity)
+    if (t.type === 'BUY')  netBuyQty[t.symbol] = (netBuyQty[t.symbol] ?? 0) + q
+    if (t.type === 'SELL') netBuyQty[t.symbol] = (netBuyQty[t.symbol] ?? 0) - q
   })
 
   const app8Holdings = {
@@ -258,22 +259,22 @@ export async function processFile({ csvFile, htmlFile, priorPositions = [] }) {
       { key: 'symbol',    label: 'Символ',  bold: true, tooltip: 'description' },
       { key: 'type',      label: 'Вид',     bold: true },
       { key: 'country',   label: 'Държава' },
-      { key: 'quantity',  label: 'Брой',        align: 'right', mono: true, decimals: 0 },
+      { key: 'quantity',  label: 'Брой',                        align: 'right', mono: true, decimals: 0 },
       { key: 'acquDate',  label: 'Дата и година на придобиване', shortLabel: 'Дата', mono: true, maxWidth: 80 },
       { key: 'costBasis', label: 'Обща цена в съответната валута', shortLabel: 'Обща цена', align: 'right', mono: true, decimals: 2 },
       { key: 'currency',  label: 'Валута' },
-      { key: 'costBGN',   label: 'Обща цена в лева', align: 'right', mono: true, decimals: 2, nullAs: '—' },
+      { key: 'costBGN',   label: `Обща цена в ${lcl}`, align: 'right', mono: true, decimals: 2, nullAs: '—' },
     ],
     rows: holdings.rows
       .flatMap((h) => {
-        const info         = instrumentInfo[h.symbol] || {}
-        const type         = info.type === 'ETF' ? 'Дялове' : 'Акции'
-        const country      = info.countryName || h.currency
-        const description  = info.description ?? ''
-        const thisYearQty  = Math.max(0, Math.min(netBuyQty[h.symbol] ?? 0, h.quantity))
-        const priorQty     = h.quantity - thisYearQty
+        const info        = instrumentInfo[h.symbol] || {}
+        const type        = info.type === 'ETF' ? 'Дялове' : 'Акции'
+        const country     = info.countryName || h.currency
+        const description = info.description ?? ''
+        const thisYearQty = Math.max(0, Math.min(netBuyQty[h.symbol] ?? 0, h.quantity))
+        const priorQty    = h.quantity - thisYearQty
         const costPerShare = h.costBasis / h.quantity
-        const acquDateStr  = lastBuyDate[h.symbol]
+        const acquDateStr = lastBuyDate[h.symbol]
           ? lastBuyDate[h.symbol].split('-').reverse().join('.')
           : null
 
@@ -284,7 +285,7 @@ export async function processFile({ csvFile, htmlFile, priorPositions = [] }) {
             costBasis: cost, currency: h.currency,
             costBGN: acquDate === 'предходна година'
               ? null
-              : toBGN(cost, h.currency, YEAR_END_DATE)?.toNumber() ?? null,
+              : toLcl(cost, h.currency, yearEndDate)?.toNumber() ?? null,
           }
         }
 
@@ -302,21 +303,21 @@ export async function processFile({ csvFile, htmlFile, priorPositions = [] }) {
   // ── App8 Part III – dividends ─────────────────────────────────────────────
   const app8Dividends = {
     columns: [
-      { key: 'symbol',              label: 'Символ', bold: true, tooltip: 'description' },
-      { key: 'description',         label: 'Наименование на лицето, изплатило дохода', shortLabel: 'Наименование', mono: true, maxWidth: 200 },
-      { key: 'countryName',         label: 'Държава' },
-      { key: 'incomeCategoryCode',  label: 'Код вид доход',   shortLabel: 'Код доход' },
-      { key: 'methodCode',          label: 'Код за прилагане на метод за избягване на двойното данъчно облагане', shortLabel: 'Код метод' },
-      { key: 'grossAmountBGN',      label: 'Брутен размер на дохода, включително платения данък (за доходи с код 8141)', shortLabel: 'Брутен доход (лв)', align: 'right', mono: true, decimals: 2, nullAs: '—' },
-      { key: 'foreignTaxPaidBGN',   label: 'Платен данък в чужбина', shortLabel: 'Данък в чужбина (лв)', align: 'right', mono: true, decimals: 2, nullAs: '—' },
-      { key: 'allowableCreditBGN',  label: 'Допустим размер на данъчния кредит', shortLabel: 'Допустим кредит (лв)', align: 'right', mono: true, decimals: 2, nullAs: '—' },
-      { key: 'dueTaxBGN',           label: 'Дължим данък, подлежащ на внасяне по реда на чл. 67, ал. 4 от ЗДДФЛ', shortLabel: 'Дължим данък (лв)', align: 'right', mono: true, decimals: 2, nullAs: '—' },
+      { key: 'symbol',             label: 'Символ', bold: true, tooltip: 'description' },
+      { key: 'description',        label: 'Наименование на лицето, изплатило дохода', shortLabel: 'Наименование', mono: true, maxWidth: 200 },
+      { key: 'countryName',        label: 'Държава' },
+      { key: 'incomeCategoryCode', label: 'Код вид доход', shortLabel: 'Код доход' },
+      { key: 'methodCode',         label: 'Код за прилагане на метод за избягване на двойното данъчно облагане', shortLabel: 'Код метод' },
+      { key: 'grossAmountBGN',     label: 'Брутен размер на дохода, включително платения данък (за доходи с код 8141)', shortLabel: `Брутен доход (${lcl})`, align: 'right', mono: true, decimals: 2, nullAs: '—' },
+      { key: 'foreignTaxPaidBGN',  label: 'Платен данък в чужбина', shortLabel: `Данък в чужбина (${lcl})`, align: 'right', mono: true, decimals: 2, nullAs: '—' },
+      { key: 'allowableCreditBGN', label: 'Допустим размер на данъчния кредит', shortLabel: `Допустим кредит (${lcl})`, align: 'right', mono: true, decimals: 2, nullAs: '—' },
+      { key: 'dueTaxBGN',          label: 'Дължим данък, подлежащ на внасяне по реда на чл. 67, ал. 4 от ЗДДФЛ', shortLabel: `Дължим данък (${lcl})`, align: 'right', mono: true, decimals: 2, nullAs: '—' },
     ],
     rows: dividends.rows.map((d) => {
-      const grossBGND    = toBGN(d.grossAmount, d.currency, d.date)
-      const withheldBGND = toBGN(d.withheldTax, d.currency, d.date)
-      const grossBGN     = grossBGND    ? grossBGND.toNumber()    : null
-      const withheldBGN  = withheldBGND ? withheldBGND.toNumber() : null
+      const grossD    = toLcl(d.grossAmount, d.currency, d.date)
+      const withheldD = toLcl(d.withheldTax, d.currency, d.date)
+      const grossBGN     = grossD    ? grossD.toNumber()    : null
+      const withheldBGN  = withheldD ? withheldD.toNumber() : null
       const bgTaxBGN     = grossBGN != null ? new Decimal(grossBGN).times(BG_DIVIDEND_TAX_RATE).toNumber() : null
 
       const partialCredit = bgTaxBGN != null && withheldBGN != null && withheldBGN < bgTaxBGN
@@ -335,13 +336,31 @@ export async function processFile({ csvFile, htmlFile, priorPositions = [] }) {
     }),
   }
 
-  // ── Enrich interest with BGN ─────────────────────────────────────────────
+  // ── Enrich interest with local currency + totals ─────────────────────────
+  const interestDataRows = [...interest.rows]
   interest.rows.forEach((r) => {
-    const d = toBGN(r.amount, r.currency, r.date)
+    const d = toLcl(r.amount, r.currency, r.date)
     r.amountBGN = d ? d.toNumber() : null
   })
+  // Update the amountBGN column label
+  const amtLclCol = interest.columns.find(c => c.key === 'amountBGN')
+  if (amtLclCol) amtLclCol.label = `Сума (${lcl})`
+  // Add totals per original currency, then local-currency grand total
+  ;['EUR', 'USD'].forEach(cur => {
+    const subset = interestDataRows.filter(r => r.currency === cur)
+    if (subset.length === 0) return
+    interest.rows.push({
+      _total: true, currency: cur, description: 'Общо',
+      amount:    subset.reduce((s, r) => s + (r.amount    ?? 0), 0),
+      amountBGN: subset.reduce((s, r) => s + (r.amountBGN ?? 0), 0),
+    })
+  })
+  interest.rows.push({
+    _total: true, currency: localCurrencyCode, description: 'Общо',
+    amountBGN: interestDataRows.reduce((s, r) => s + (r.amountBGN ?? 0), 0),
+  })
 
-  // ── Holdings totals rows ─────────────────────────────────────────────────
+  // ── Holdings totals ──────────────────────────────────────────────────────
   const holdingSumCols = ['quantity', 'costBasis', 'costPrice', 'value', 'unrealizedPL']
   ;['EUR', 'USD'].forEach(cur => {
     const subset = holdings.rows.filter(r => r.currency === cur)
@@ -357,5 +376,8 @@ export async function processFile({ csvFile, htmlFile, priorPositions = [] }) {
     dividends,
     interest,
     taxSummary: { app5, app13, app8Holdings, app8Dividends },
+    taxYear,
+    localCurrencyCode,
+    localCurrencyLabel,
   }
 }


### PR DESCRIPTION
…ual-currency support

- Remove separate "Потвърди" button from PriorYearPositionsForm; prior-year positions are now edited inline and read directly by Изчисли (task 1)
- Move checkbox + Изчисли + Зареди демо row below the prior-year form (task 1)
- Add per-currency and grand-total rows to the interest table (task 2)
- Detect tax year from Activity Statement CSV Period header; throw for < 2025 (task 3)
- 2025 → BGN (лв), 2026+ → EUR (евро); toLocalCurrency() handles both (task 3)
- Normalize 2026.json USD/EUR rates to USD/BGN via EUR_BGN multiplier so findUsdRate() always returns a consistent unit; toLocalCurrency divides back to EUR for 2026 reporting (task 3)
- Replace all hardcoded "лв" with dynamic lcl / localCurrencyLabel (task 3)
- Add parseTaxYear.js parser; update fxRates.js, processFile.js, inferPriorPositions.js, PriorYearPositionsForm, PriorYearApproxWarning, TaxApp5, TaxApp13, App.jsx

https://claude.ai/code/session_015zdxj2aGvAdiC4KtM4tBaK