### PR TITLE
fix: use toLocalCurrency for fully-sold prior-year symbols in inferPr…

### DIFF
--- a/src/services/inferPriorPositions.js
+++ b/src/services/inferPriorPositions.js
@@ -110,7 +110,7 @@ export function inferPriorPositions({ htmlTrades, openPositions, csvTradeBasis, 
     const priorCostD   = sym.sellBasisUSD.minus(sym.buyCostUSD)
     if (priorCostD.lte(0)) continue
 
-    const priorCostBGN = toBGN(priorCostD, sym.currency, PREV_YEAR_END_DATE)
+    const priorCostBGN = toLocalCurrency(priorCostD, sym.currency, prevYearEndDate, taxYear)
 
     result.push({
       symbol,


### PR DESCRIPTION
…iorPositions

The "fully sold" branch still called toBGN/PREV_YEAR_END_DATE which were removed in the EUR/BGN refactor, causing a ReferenceError that silenced prior-year position detection and hid the form when loading demo data.

https://claude.ai/code/session_015zdxj2aGvAdiC4KtM4tBaK