### PR TITLE
Add unit tests for parser and tax calculation logic (issue #19)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
-        "vite": "^8.0.4"
+        "vite": "^8.0.4",
+        "vitest": "^4.1.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1281,6 +1282,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1291,6 +1299,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1372,6 +1398,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1434,6 +1573,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
@@ -1554,6 +1703,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1735,6 +1894,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1932,6 +2098,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1940,6 +2116,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2686,6 +2872,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2746,6 +2942,17 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2867,6 +3074,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3133,6 +3347,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -3151,6 +3372,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -3196,6 +3431,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -3211,6 +3463,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -3362,6 +3624,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -3385,6 +3737,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -33,6 +35,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
-    "vite": "^8.0.4"
+    "vite": "^8.0.4",
+    "vitest": "^4.1.4"
   }
 }

--- a/src/domain/__tests__/tradeSummary.test.js
+++ b/src/domain/__tests__/tradeSummary.test.js
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest'
+import { buildTradeTotals, buildTaxSummary } from '../tradeSummary.js'
+
+function makeSell(fields = {}) {
+  return {
+    side:            'SELL',
+    currency:        fields.currency        ?? 'USD',
+    taxable:         fields.taxable         ?? true,
+    taxExemptLabel:  fields.taxExemptLabel  ?? 'Облагаем',
+    proceeds:        fields.proceeds        ?? 100,
+    commission:      fields.commission      ?? -2,
+    fee:             fields.fee             ?? 0,
+    totalWithFee:    fields.totalWithFee    ?? 98,
+    totalWithFeeBGN: fields.totalWithFeeBGN ?? 191.67,
+    costBasisBGN:    fields.costBasisBGN    ?? 176.03,
+  }
+}
+
+function makeBuy(fields = {}) {
+  return {
+    side:            'BUY',
+    currency:        fields.currency        ?? 'USD',
+    taxable:         null,
+    taxExemptLabel:  '',
+    proceeds:        fields.proceeds        ?? -100,
+    commission:      fields.commission      ?? -2,
+    fee:             fields.fee             ?? 0,
+    totalWithFee:    fields.totalWithFee    ?? -102,
+    totalWithFeeBGN: fields.totalWithFeeBGN ?? -199.49,
+    costBasisBGN:    fields.costBasisBGN    ?? null,
+  }
+}
+
+describe('buildTradeTotals', () => {
+  it('returns empty array for empty input', () => {
+    expect(buildTradeTotals([])).toEqual([])
+  })
+
+  it('builds total rows grouped by taxExemptLabel and currency', () => {
+    const rows = [
+      makeSell({ currency: 'USD', taxExemptLabel: 'Облагаем', totalWithFee: 100, totalWithFeeBGN: 195.58 }),
+      makeSell({ currency: 'EUR', taxExemptLabel: 'Облагаем', totalWithFee: 200, totalWithFeeBGN: 391.17 }),
+    ]
+    const totals = buildTradeTotals(rows)
+    expect(totals.some(r => r.currency === 'USD' && r.taxExemptLabel === 'Облагаем')).toBe(true)
+    expect(totals.some(r => r.currency === 'EUR' && r.taxExemptLabel === 'Облагаем')).toBe(true)
+  })
+
+  it('includes a BGN grand total row per group', () => {
+    const rows = [makeSell({ currency: 'USD', taxExemptLabel: 'Облагаем', totalWithFeeBGN: 195.58 })]
+    const totals = buildTradeTotals(rows, 'BGN')
+    expect(totals.some(r => r.currency === 'BGN')).toBe(true)
+  })
+
+  it('marks all total rows with _total flag', () => {
+    const rows = [makeSell()]
+    const totals = buildTradeTotals(rows)
+    expect(totals.every(r => r._total === true)).toBe(true)
+  })
+
+  it('sums proceeds, commission, fee and totalWithFee correctly', () => {
+    const rows = [
+      makeSell({ currency: 'USD', taxExemptLabel: 'Облагаем', proceeds: 100, commission: -2, fee: -1, totalWithFee: 97 }),
+      makeSell({ currency: 'USD', taxExemptLabel: 'Облагаем', proceeds: 200, commission: -3, fee: -2, totalWithFee: 195 }),
+    ]
+    const totals = buildTradeTotals(rows)
+    const usdTotal = totals.find(r => r.currency === 'USD' && r.taxExemptLabel === 'Облагаем')
+    expect(usdTotal.proceeds).toBeCloseTo(300)
+    expect(usdTotal.commission).toBeCloseTo(-5)
+    expect(usdTotal.totalWithFee).toBeCloseTo(292)
+  })
+
+  it('handles Освободен (exempt) group separately', () => {
+    const rows = [
+      makeSell({ taxExemptLabel: 'Облагаем', totalWithFeeBGN: 100 }),
+      makeSell({ taxExemptLabel: 'Освободен', totalWithFeeBGN: 200 }),
+    ]
+    const totals = buildTradeTotals(rows)
+    const taxableTotal = totals.find(r => r.taxExemptLabel === 'Облагаем' && r.currency === 'BGN')
+    const exemptTotal  = totals.find(r => r.taxExemptLabel === 'Освободен' && r.currency === 'BGN')
+    expect(taxableTotal?.totalWithFeeBGN).toBeCloseTo(100)
+    expect(exemptTotal?.totalWithFeeBGN).toBeCloseTo(200)
+  })
+
+  it('skips currency groups with no trades', () => {
+    // Only USD trades — no EUR totals row should appear
+    const rows = [makeSell({ currency: 'USD', taxExemptLabel: 'Облагаем' })]
+    const totals = buildTradeTotals(rows)
+    expect(totals.some(r => r.currency === 'EUR')).toBe(false)
+  })
+})
+
+describe('buildTaxSummary', () => {
+  it('returns app5 and app13 summaries', () => {
+    const result = buildTaxSummary([])
+    expect(result).toHaveProperty('app5')
+    expect(result).toHaveProperty('app13')
+  })
+
+  it('returns zeros for empty input', () => {
+    const { app5, app13 } = buildTaxSummary([])
+    expect(app5.profits).toBe(0)
+    expect(app5.losses).toBe(0)
+    expect(app13.profits).toBe(0)
+  })
+
+  it('calculates taxable sell profits in app5', () => {
+    const rows = [
+      makeSell({ taxable: true, totalWithFeeBGN: 200, costBasisBGN: 150 }),
+    ]
+    const { app5 } = buildTaxSummary(rows)
+    expect(app5.profits).toBeCloseTo(50)
+    expect(app5.losses).toBe(0)
+  })
+
+  it('calculates taxable sell losses in app5', () => {
+    const rows = [
+      makeSell({ taxable: true, totalWithFeeBGN: 100, costBasisBGN: 150 }),
+    ]
+    const { app5 } = buildTaxSummary(rows)
+    expect(app5.profits).toBe(0)
+    expect(app5.losses).toBeCloseTo(50)
+  })
+
+  it('puts exempt sells into app13, not app5', () => {
+    const rows = [
+      makeSell({ taxable: false, totalWithFeeBGN: 200, costBasisBGN: 150 }),
+    ]
+    const { app5, app13 } = buildTaxSummary(rows)
+    expect(app5.profits).toBe(0)
+    expect(app13.profits).toBeCloseTo(50)
+  })
+
+  it('ignores BUY rows when calculating summaries', () => {
+    const rows = [
+      makeBuy({ totalWithFeeBGN: -500, costBasisBGN: null }),
+    ]
+    const { app5, app13 } = buildTaxSummary(rows)
+    expect(app5.profits).toBe(0)
+    expect(app13.profits).toBe(0)
+  })
+
+  it('handles mixed profits and losses in the same group', () => {
+    const rows = [
+      makeSell({ taxable: true, totalWithFeeBGN: 200, costBasisBGN: 150 }),
+      makeSell({ taxable: true, totalWithFeeBGN: 80,  costBasisBGN: 100 }),
+    ]
+    const { app5 } = buildTaxSummary(rows)
+    expect(app5.profits).toBeCloseTo(50)
+    expect(app5.losses).toBeCloseTo(20)
+  })
+
+  it('calculates totalProceedsBGN and totalCostBasisBGN', () => {
+    const rows = [
+      makeSell({ taxable: true, totalWithFeeBGN: 200, costBasisBGN: 150 }),
+      makeSell({ taxable: true, totalWithFeeBGN: 300, costBasisBGN: 200 }),
+    ]
+    const { app5 } = buildTaxSummary(rows)
+    expect(app5.totalProceedsBGN).toBeCloseTo(500)
+    expect(app5.totalCostBasisBGN).toBeCloseTo(350)
+  })
+})

--- a/src/domain/parser/__tests__/parseCsvTrades.test.js
+++ b/src/domain/parser/__tests__/parseCsvTrades.test.js
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest'
+import { parseCsvTrades, buildCsvTradeBasis } from '../parseCsvTrades.js'
+import Decimal from 'decimal.js'
+
+function makeHeader() {
+  return [
+    'Trades', 'Header', 'DataDiscriminator',
+    'Asset Category', 'Currency', 'Symbol', 'Date/Time', 'Settle Date/Time',
+    'Exchange', 'Buy/Sell', 'Quantity', 'Price', 'Proceeds', 'Comm/Fee', 'Basis',
+    'Realized P/L', 'Code',
+  ]
+}
+
+function makeTrade(fields = {}) {
+  return [
+    'Trades', 'Data', 'Order',
+    fields.assetCategory ?? 'Stocks',
+    fields.currency      ?? 'USD',
+    fields.symbol        ?? 'AAPL',
+    fields.datetime      ?? '"2025-03-15, 10:30:00"',
+    fields.settleDate    ?? '2025-03-17',
+    fields.exchange      ?? 'NASDAQ',
+    fields.side          ?? 'BUY',
+    fields.quantity      ?? '10',
+    fields.price         ?? '150.00',
+    fields.proceeds      ?? '-1500.00',
+    fields.commission    ?? '-5.00',
+    fields.basis         ?? '-1505.00',
+    fields.realizedPL    ?? '0',
+    fields.code          ?? 'O',
+  ]
+}
+
+describe('parseCsvTrades', () => {
+  it('returns empty array when no Trades header exists', () => {
+    expect(parseCsvTrades([])).toEqual([])
+    expect(parseCsvTrades([['Dividends', 'Header', 'DataDiscriminator']])).toEqual([])
+  })
+
+  it('parses a single BUY trade correctly', () => {
+    const rows = [makeHeader(), makeTrade()]
+    const result = parseCsvTrades(rows)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      assetCategory: 'Stocks',
+      currency:      'USD',
+      symbol:        'AAPL',
+      exchange:      'NASDAQ',
+      side:          'BUY',
+      quantity:      '10',
+      price:         '150.00',
+      proceeds:      '-1500.00',
+      commission:    '-5.00',
+      basis:         '-1505.00',
+      code:          'O',
+    })
+  })
+
+  it('strips quotes from datetime field', () => {
+    const rows = [makeHeader(), makeTrade({ datetime: '"2025-03-15, 10:30:00"' })]
+    const result = parseCsvTrades(rows)
+    expect(result[0].datetime).toBe('2025-03-15, 10:30:00')
+  })
+
+  it('parses multiple trades', () => {
+    const rows = [
+      makeHeader(),
+      makeTrade({ symbol: 'AAPL', side: 'BUY' }),
+      makeTrade({ symbol: 'MSFT', side: 'SELL', quantity: '-5' }),
+    ]
+    expect(parseCsvTrades(rows)).toHaveLength(2)
+  })
+
+  it('only parses rows where DataDiscriminator is "Order"', () => {
+    const rows = [
+      makeHeader(),
+      makeTrade(),
+      ['Trades', 'Data', 'SubTotal', 'Stocks', 'USD', '', '', '', '', '', '', '', '-1500', '-5', '', '', ''],
+    ]
+    expect(parseCsvTrades(rows)).toHaveLength(1)
+  })
+
+  it('parses a SELL trade correctly', () => {
+    const rows = [
+      makeHeader(),
+      makeTrade({ side: 'SELL', quantity: '-10', proceeds: '1800.00', basis: '-1505.00', realizedPL: '295.00' }),
+    ]
+    const result = parseCsvTrades(rows)
+    expect(result[0].side).toBe('SELL')
+    expect(result[0].quantity).toBe('-10')
+    expect(result[0].proceeds).toBe('1800.00')
+  })
+})
+
+describe('buildCsvTradeBasis', () => {
+  it('returns an empty Map for empty input', () => {
+    const map = buildCsvTradeBasis([])
+    expect(map.size).toBe(0)
+  })
+
+  it('ignores BUY trades (non-negative quantity)', () => {
+    const trades = parseCsvTrades([
+      makeHeader(),
+      makeTrade({ side: 'BUY', quantity: '10', proceeds: '-1500.00', basis: '-1505.00' }),
+    ])
+    expect(buildCsvTradeBasis(trades).size).toBe(0)
+  })
+
+  it('builds a key from SELL trade: SYMBOL|DATE|QTY', () => {
+    const trades = parseCsvTrades([
+      makeHeader(),
+      makeTrade({
+        side:     'SELL',
+        quantity: '-10',
+        datetime: '"2025-06-15, 09:30:00"',
+        symbol:   'AAPL',
+        basis:    '-1505.00',
+      }),
+    ])
+    const map = buildCsvTradeBasis(trades)
+    expect(map.has('AAPL|2025-06-15|10')).toBe(true)
+  })
+
+  it('stores basis as positive Decimal for SELL trades', () => {
+    const trades = parseCsvTrades([
+      makeHeader(),
+      makeTrade({
+        side:     'SELL',
+        quantity: '-10',
+        datetime: '"2025-06-15, 09:30:00"',
+        symbol:   'AAPL',
+        basis:    '-1505.00',
+      }),
+    ])
+    const map = buildCsvTradeBasis(trades)
+    const basis = map.get('AAPL|2025-06-15|10')
+    expect(basis).toBeInstanceOf(Decimal)
+    expect(basis.toNumber()).toBeCloseTo(1505)
+  })
+
+  it('handles multiple SELL trades for different symbols', () => {
+    const trades = parseCsvTrades([
+      makeHeader(),
+      makeTrade({ symbol: 'AAPL', side: 'SELL', quantity: '-5', datetime: '"2025-06-15, 09:30:00"', basis: '-750.00' }),
+      makeTrade({ symbol: 'MSFT', side: 'SELL', quantity: '-3', datetime: '"2025-07-01, 10:00:00"', basis: '-450.00' }),
+    ])
+    const map = buildCsvTradeBasis(trades)
+    expect(map.size).toBe(2)
+    expect(map.has('AAPL|2025-06-15|5')).toBe(true)
+    expect(map.has('MSFT|2025-07-01|3')).toBe(true)
+  })
+})

--- a/src/domain/parser/__tests__/parseDividends.test.js
+++ b/src/domain/parser/__tests__/parseDividends.test.js
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+import { parseDividends, parseWithholdingTax } from '../parseDividends.js'
+
+// Helper: build rows with a Dividends header + optional data rows
+function makeRows(dataRows = []) {
+  const header = ['Dividends', 'Header', 'Currency', 'Date', 'Description', 'Amount']
+  return [header, ...dataRows]
+}
+
+function makeWtRows(dataRows = []) {
+  const header = ['Withholding Tax', 'Header', 'Currency', 'Date', 'Description', 'Amount', 'Code']
+  return [header, ...dataRows]
+}
+
+describe('parseDividends', () => {
+  it('returns empty array when no Dividends header exists', () => {
+    expect(parseDividends([])).toEqual([])
+    expect(parseDividends([['Other', 'Header', 'Currency', 'Date', 'Description', 'Amount']])).toEqual([])
+  })
+
+  it('parses a single dividend row correctly', () => {
+    const rows = makeRows([
+      ['Dividends', 'Data', 'USD', '2025-03-15', 'AAPL(US0378331005) Cash Dividend', '10.00'],
+    ])
+    const result = parseDividends(rows)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      currency: 'USD',
+      date: '2025-03-15',
+      description: 'AAPL(US0378331005) Cash Dividend',
+      amount: '10.00',
+    })
+  })
+
+  it('parses multiple dividend rows', () => {
+    const rows = makeRows([
+      ['Dividends', 'Data', 'USD', '2025-03-15', 'AAPL Dividend', '10.00'],
+      ['Dividends', 'Data', 'EUR', '2025-04-01', 'EXS1 Dividend', '5.50'],
+    ])
+    const result = parseDividends(rows)
+    expect(result).toHaveLength(2)
+  })
+
+  it('skips rows where Currency is "Total"', () => {
+    const rows = makeRows([
+      ['Dividends', 'Data', 'USD', '2025-03-15', 'AAPL Dividend', '10.00'],
+      ['Dividends', 'Data', 'Total', '', '', '10.00'],
+    ])
+    expect(parseDividends(rows)).toHaveLength(1)
+  })
+
+  it('skips rows where Currency is "Total in EUR"', () => {
+    const rows = makeRows([
+      ['Dividends', 'Data', 'USD', '2025-03-15', 'AAPL Dividend', '10.00'],
+      ['Dividends', 'Data', 'Total in EUR', '', '', '10.00'],
+    ])
+    expect(parseDividends(rows)).toHaveLength(1)
+  })
+
+  it('skips rows where Currency is "Total Dividends in EUR"', () => {
+    const rows = makeRows([
+      ['Dividends', 'Data', 'USD', '2025-03-15', 'AAPL Dividend', '10.00'],
+      ['Dividends', 'Data', 'Total Dividends in EUR', '', '', '10.00'],
+    ])
+    expect(parseDividends(rows)).toHaveLength(1)
+  })
+
+  it('skips rows with zero amount', () => {
+    const rows = makeRows([
+      ['Dividends', 'Data', 'USD', '2025-03-15', 'AAPL Dividend', '0'],
+    ])
+    expect(parseDividends(rows)).toHaveLength(0)
+  })
+
+  it('skips rows with negative amount', () => {
+    const rows = makeRows([
+      ['Dividends', 'Data', 'USD', '2025-03-15', 'AAPL Dividend', '-5.00'],
+    ])
+    expect(parseDividends(rows)).toHaveLength(0)
+  })
+
+  it('handles whitespace in column names and values', () => {
+    const header = ['Dividends', 'Header', ' Currency ', ' Date ', ' Description ', ' Amount ']
+    const rows = [
+      header,
+      ['Dividends', 'Data', ' USD ', '2025-03-15', 'AAPL Dividend', '10.00'],
+    ]
+    const result = parseDividends(rows)
+    expect(result).toHaveLength(1)
+    expect(result[0].currency).toBe('USD')
+  })
+
+  it('ignores non-Dividends rows mixed in', () => {
+    const rows = makeRows([
+      ['Dividends', 'Data', 'USD', '2025-03-15', 'AAPL Dividend', '10.00'],
+      ['Trades', 'Data', 'USD', '2025-03-15', 'AAPL', '100'],
+    ])
+    expect(parseDividends(rows)).toHaveLength(1)
+  })
+})
+
+describe('parseWithholdingTax', () => {
+  it('returns empty array when no Withholding Tax header exists', () => {
+    expect(parseWithholdingTax([])).toEqual([])
+  })
+
+  it('parses a withholding tax row correctly', () => {
+    const rows = makeWtRows([
+      ['Withholding Tax', 'Data', 'USD', '2025-03-15', 'AAPL(US0378331005) Cash Dividend', '-1.50', 'Po'],
+    ])
+    const result = parseWithholdingTax(rows)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      currency: 'USD',
+      date: '2025-03-15',
+      description: 'AAPL(US0378331005) Cash Dividend',
+      amount: '-1.50',
+      code: 'Po',
+    })
+  })
+
+  it('skips rows where Currency starts with "Total"', () => {
+    const rows = makeWtRows([
+      ['Withholding Tax', 'Data', 'USD', '2025-03-15', 'AAPL Dividend', '-1.50', 'Po'],
+      ['Withholding Tax', 'Data', 'Total in EUR', '', '', '-1.50', ''],
+    ])
+    expect(parseWithholdingTax(rows)).toHaveLength(1)
+  })
+
+  it('includes negative amounts (unlike parseDividends)', () => {
+    const rows = makeWtRows([
+      ['Withholding Tax', 'Data', 'USD', '2025-03-15', 'AAPL Dividend', '-1.50', 'Po'],
+    ])
+    const result = parseWithholdingTax(rows)
+    expect(result).toHaveLength(1)
+    expect(result[0].amount).toBe('-1.50')
+  })
+
+  it('handles empty input gracefully', () => {
+    expect(parseWithholdingTax([])).toEqual([])
+  })
+})

--- a/src/domain/parser/__tests__/parseInstruments.test.js
+++ b/src/domain/parser/__tests__/parseInstruments.test.js
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest'
+import { parseInstruments, buildInstrumentInfo, expandByAliases } from '../parseInstruments.js'
+
+function makeRows(dataRows = []) {
+  const header = [
+    'Financial Instrument Information', 'Header',
+    'Asset Category', 'Symbol', 'Description', 'Conid',
+    'Security ID', 'Underlying', 'Listing Exch', 'Multiplier', 'Type', 'Code',
+  ]
+  return [header, ...dataRows]
+}
+
+function makeInstrumentRow(fields = {}) {
+  return [
+    'Financial Instrument Information', 'Data',
+    fields.assetCategory    ?? 'Stocks',
+    fields.symbol           ?? 'AAPL',
+    fields.description      ?? 'Apple Inc',
+    fields.conid            ?? '265598',
+    fields.securityId       ?? 'US0378331005',
+    fields.underlying       ?? '',
+    fields.listingExchange  ?? 'NASDAQ',
+    fields.multiplier       ?? '1',
+    fields.type             ?? 'COMMON',
+    fields.code             ?? '',
+  ]
+}
+
+describe('parseInstruments', () => {
+  it('returns empty array when no header exists', () => {
+    expect(parseInstruments([])).toEqual([])
+    expect(parseInstruments([['Dividends', 'Header']])).toEqual([])
+  })
+
+  it('parses a single instrument row', () => {
+    const rows = makeRows([makeInstrumentRow()])
+    const result = parseInstruments(rows)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      assetCategory:   'Stocks',
+      symbol:          'AAPL',
+      description:     'Apple Inc',
+      conid:           '265598',
+      securityId:      'US0378331005',
+      listingExchange: 'NASDAQ',
+      multiplier:      '1',
+      type:            'COMMON',
+    })
+  })
+
+  it('parses multiple instruments', () => {
+    const rows = makeRows([
+      makeInstrumentRow({ symbol: 'AAPL' }),
+      makeInstrumentRow({ symbol: 'MSFT', description: 'Microsoft Corp', securityId: 'US5949181045' }),
+    ])
+    expect(parseInstruments(rows)).toHaveLength(2)
+  })
+
+  it('handles comma-separated symbol aliases in symbol field', () => {
+    const rows = makeRows([
+      makeInstrumentRow({ symbol: 'EXS1, EXS1d' }),
+    ])
+    const result = parseInstruments(rows)
+    expect(result[0].symbol).toBe('EXS1, EXS1d')
+  })
+})
+
+describe('buildInstrumentInfo', () => {
+  it('returns empty object for empty instruments array', () => {
+    expect(buildInstrumentInfo([])).toEqual({})
+  })
+
+  it('creates a symbol-keyed lookup from instruments', () => {
+    const instruments = parseInstruments(makeRows([
+      makeInstrumentRow({ symbol: 'AAPL', securityId: 'US0378331005', type: 'COMMON' }),
+    ]))
+    const info = buildInstrumentInfo(instruments)
+    expect(info['AAPL']).toBeDefined()
+    expect(info['AAPL'].type).toBe('COMMON')
+    expect(info['AAPL'].securityId).toBe('US0378331005')
+  })
+
+  it('derives country code from ISIN prefix (first 2 chars of securityId)', () => {
+    const instruments = parseInstruments(makeRows([
+      makeInstrumentRow({ symbol: 'AAPL', securityId: 'US0378331005' }),
+      makeInstrumentRow({ symbol: 'EXS1', securityId: 'IE00B4L5Y983', type: 'ETF', listingExchange: 'IBIS' }),
+    ]))
+    const info = buildInstrumentInfo(instruments)
+    expect(info['AAPL'].country).toBe('US')
+    expect(info['EXS1'].country).toBe('IE')
+  })
+
+  it('expands comma-separated aliases to separate keys', () => {
+    const instruments = parseInstruments(makeRows([
+      makeInstrumentRow({ symbol: 'EXS1, EXS1d', securityId: 'IE00B4L5Y983' }),
+    ]))
+    const info = buildInstrumentInfo(instruments)
+    expect(info['EXS1']).toBeDefined()
+    expect(info['EXS1d']).toBeDefined()
+    expect(info['EXS1'].securityId).toBe('IE00B4L5Y983')
+    expect(info['EXS1d'].securityId).toBe('IE00B4L5Y983')
+  })
+
+  it('stores all alias symbols in the aliases array', () => {
+    const instruments = parseInstruments(makeRows([
+      makeInstrumentRow({ symbol: 'EXS1, EXS1d' }),
+    ]))
+    const info = buildInstrumentInfo(instruments)
+    expect(info['EXS1'].aliases).toContain('EXS1')
+    expect(info['EXS1'].aliases).toContain('EXS1d')
+  })
+})
+
+describe('expandByAliases', () => {
+  it('returns the same dict when no aliases exist', () => {
+    const dict = { AAPL: 100 }
+    const instrumentInfo = { AAPL: { aliases: ['AAPL'] } }
+    const result = expandByAliases(dict, instrumentInfo)
+    expect(result['AAPL']).toBe(100)
+  })
+
+  it('adds alias keys pointing to the same value', () => {
+    const dict = { EXS1: 200 }
+    const instrumentInfo = { EXS1: { aliases: ['EXS1', 'EXS1d'] } }
+    const result = expandByAliases(dict, instrumentInfo)
+    expect(result['EXS1d']).toBe(200)
+  })
+
+  it('does not overwrite existing keys', () => {
+    const dict = { EXS1: 200, EXS1d: 300 }
+    const instrumentInfo = { EXS1: { aliases: ['EXS1', 'EXS1d'] } }
+    const result = expandByAliases(dict, instrumentInfo)
+    expect(result['EXS1d']).toBe(300)
+  })
+
+  it('does not mutate the original dict', () => {
+    const dict = { EXS1: 200 }
+    const instrumentInfo = { EXS1: { aliases: ['EXS1', 'EXS1d'] } }
+    expandByAliases(dict, instrumentInfo)
+    expect(dict['EXS1d']).toBeUndefined()
+  })
+
+  it('handles symbol not in instrumentInfo gracefully', () => {
+    const dict = { UNKNOWN: 50 }
+    const instrumentInfo = {}
+    const result = expandByAliases(dict, instrumentInfo)
+    expect(result['UNKNOWN']).toBe(50)
+  })
+})

--- a/src/domain/parser/__tests__/parseInterest.test.js
+++ b/src/domain/parser/__tests__/parseInterest.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { parseInterest } from '../parseInterest.js'
+
+function makeRows(dataRows = []) {
+  const header = ['Interest', 'Header', 'Currency', 'Date', 'Description', 'Amount']
+  return [header, ...dataRows]
+}
+
+describe('parseInterest', () => {
+  it('returns empty array when no Interest header exists', () => {
+    expect(parseInterest([])).toEqual([])
+    expect(parseInterest([['Dividends', 'Header', 'Currency', 'Date', 'Description', 'Amount']])).toEqual([])
+  })
+
+  it('parses a single interest row correctly', () => {
+    const rows = makeRows([
+      ['Interest', 'Data', 'USD', '2025-02-28', 'USD Credit Interest for Feb-2025', '12.34'],
+    ])
+    const result = parseInterest(rows)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      currency: 'USD',
+      date: '2025-02-28',
+      description: 'USD Credit Interest for Feb-2025',
+      amount: '12.34',
+    })
+  })
+
+  it('parses multiple interest rows', () => {
+    const rows = makeRows([
+      ['Interest', 'Data', 'USD', '2025-01-31', 'USD Credit Interest', '5.00'],
+      ['Interest', 'Data', 'EUR', '2025-02-28', 'EUR Credit Interest', '3.20'],
+    ])
+    expect(parseInterest(rows)).toHaveLength(2)
+  })
+
+  it('skips rows where Currency is "Total"', () => {
+    const rows = makeRows([
+      ['Interest', 'Data', 'USD', '2025-01-31', 'USD Interest', '5.00'],
+      ['Interest', 'Data', 'Total', '', 'Total', '5.00'],
+    ])
+    expect(parseInterest(rows)).toHaveLength(1)
+  })
+
+  it('skips rows where Currency is "Total in EUR"', () => {
+    const rows = makeRows([
+      ['Interest', 'Data', 'USD', '2025-01-31', 'USD Interest', '5.00'],
+      ['Interest', 'Data', 'Total in EUR', '', '', '5.00'],
+    ])
+    expect(parseInterest(rows)).toHaveLength(1)
+  })
+
+  it('skips rows where Currency is "Total Interest in EUR"', () => {
+    const rows = makeRows([
+      ['Interest', 'Data', 'USD', '2025-01-31', 'USD Interest', '5.00'],
+      ['Interest', 'Data', 'Total Interest in EUR', '', '', '5.00'],
+    ])
+    expect(parseInterest(rows)).toHaveLength(1)
+  })
+
+  it('skips rows with zero amount', () => {
+    const rows = makeRows([
+      ['Interest', 'Data', 'USD', '2025-01-31', 'USD Interest', '0'],
+    ])
+    expect(parseInterest(rows)).toHaveLength(0)
+  })
+
+  it('skips rows with negative amount', () => {
+    const rows = makeRows([
+      ['Interest', 'Data', 'USD', '2025-01-31', 'USD Debit Interest', '-2.50'],
+    ])
+    expect(parseInterest(rows)).toHaveLength(0)
+  })
+
+  it('ignores rows from other sections', () => {
+    const rows = makeRows([
+      ['Interest', 'Data', 'USD', '2025-01-31', 'USD Interest', '5.00'],
+      ['Dividends', 'Data', 'USD', '2025-01-31', 'AAPL Dividend', '10.00'],
+    ])
+    expect(parseInterest(rows)).toHaveLength(1)
+  })
+})

--- a/src/domain/parser/__tests__/parseOpenPositions.test.js
+++ b/src/domain/parser/__tests__/parseOpenPositions.test.js
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import { parseOpenPositions, buildOpenPositions } from '../parseOpenPositions.js'
+
+// Real IBKR CSV: index 2 of the header row is 'DataDiscriminator';
+// data rows have 'Summary' at index 2 as the discriminator value.
+function makeHeader() {
+  return [
+    'Open Positions', 'Header',
+    'DataDiscriminator',
+    'Asset Category', 'Currency', 'Symbol', 'Quantity', 'Mult',
+    'Cost Price', 'Cost Basis', 'Close Price', 'Value', 'Unrealized P/L', 'Code',
+  ]
+}
+
+function makePositionRow(fields = {}) {
+  return [
+    'Open Positions', 'Data', 'Summary',
+    fields.assetCategory ?? 'Stocks',
+    fields.currency      ?? 'USD',
+    fields.symbol        ?? 'AAPL',
+    fields.quantity      ?? '100',
+    fields.multiplier    ?? '1',
+    fields.costPrice     ?? '150.00',
+    fields.costBasis     ?? '15000.00',
+    fields.closePrice    ?? '180.00',
+    fields.value         ?? '18000.00',
+    fields.unrealizedPL  ?? '3000.00',
+    fields.code          ?? '',
+  ]
+}
+
+describe('parseOpenPositions', () => {
+  it('returns empty array when no Open Positions header exists', () => {
+    expect(parseOpenPositions([])).toEqual([])
+    expect(parseOpenPositions([['Trades', 'Header']])).toEqual([])
+  })
+
+  it('parses a single position correctly', () => {
+    const rows = [makeHeader(), makePositionRow()]
+    const result = parseOpenPositions(rows)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      assetCategory: 'Stocks',
+      currency:      'USD',
+      symbol:        'AAPL',
+      quantity:      '100',
+      costPrice:     '150.00',
+      costBasis:     '15000.00',
+      closePrice:    '180.00',
+      value:         '18000.00',
+      unrealizedPL:  '3000.00',
+    })
+  })
+
+  it('only includes Summary rows, not Total rows', () => {
+    const rows = [
+      makeHeader(),
+      makePositionRow(),
+      ['Open Positions', 'Data', 'Total', 'Stocks', 'USD', '', '100', '1', '', '15000.00', '', '18000.00', '3000.00', ''],
+    ]
+    expect(parseOpenPositions(rows)).toHaveLength(1)
+  })
+
+  it('parses multiple positions', () => {
+    const rows = [
+      makeHeader(),
+      makePositionRow({ symbol: 'AAPL' }),
+      makePositionRow({ symbol: 'MSFT', costBasis: '5000.00' }),
+    ]
+    expect(parseOpenPositions(rows)).toHaveLength(2)
+  })
+})
+
+describe('buildOpenPositions', () => {
+  it('returns columns and rows', () => {
+    const rawPositions = parseOpenPositions([makeHeader(), makePositionRow()])
+    const result = buildOpenPositions(rawPositions)
+    expect(result).toHaveProperty('columns')
+    expect(result).toHaveProperty('rows')
+    expect(Array.isArray(result.columns)).toBe(true)
+    expect(Array.isArray(result.rows)).toBe(true)
+  })
+
+  it('converts quantity and costBasis to numbers', () => {
+    const rawPositions = parseOpenPositions([makeHeader(), makePositionRow()])
+    const { rows } = buildOpenPositions(rawPositions)
+    expect(typeof rows[0].quantity).toBe('number')
+    expect(typeof rows[0].costBasis).toBe('number')
+  })
+
+  it('uses calculated costBasis from positionsCostBasis when available', () => {
+    const rawPositions = parseOpenPositions([makeHeader(), makePositionRow({ symbol: 'AAPL', costBasis: '15000.00' })])
+    const positionsCostBasis = { AAPL: { cost: 12000, qty: 100 } }
+    const { rows } = buildOpenPositions(rawPositions, {}, positionsCostBasis)
+    expect(rows[0].costBasis).toBe(12000)
+  })
+
+  it('falls back to raw costBasis when positionsCostBasis has no entry', () => {
+    const rawPositions = parseOpenPositions([makeHeader(), makePositionRow({ costBasis: '15000.00' })])
+    const { rows } = buildOpenPositions(rawPositions, {}, {})
+    expect(rows[0].costBasis).toBeCloseTo(15000)
+  })
+
+  it('enriches rows with country from instrumentInfo', () => {
+    const rawPositions = parseOpenPositions([makeHeader(), makePositionRow({ symbol: 'AAPL' })])
+    const instrumentInfo = { AAPL: { countryName: 'САЩ', country: 'US' } }
+    const { rows } = buildOpenPositions(rawPositions, instrumentInfo, {})
+    expect(rows[0].country).toBe('САЩ')
+  })
+
+  it('handles empty positions array', () => {
+    const { rows, columns } = buildOpenPositions([])
+    expect(rows).toHaveLength(0)
+    expect(columns.length).toBeGreaterThan(0)
+  })
+
+  it('handles comma-formatted numbers', () => {
+    const rawPositions = parseOpenPositions([makeHeader(), makePositionRow({ costBasis: '1,500,000.00', quantity: '1,000' })])
+    const { rows } = buildOpenPositions(rawPositions)
+    expect(rows[0].costBasis).toBeCloseTo(1500000)
+    expect(rows[0].quantity).toBeCloseTo(1000)
+  })
+})

--- a/src/domain/parser/__tests__/parseStatementInfo.test.js
+++ b/src/domain/parser/__tests__/parseStatementInfo.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { parseStatementInfo } from '../parseStatementInfo.js'
+
+function makeStatementRows(overrides = {}) {
+  const defaults = {
+    BrokerName:    'Interactive Brokers LLC',
+    BrokerAddress: '1 Pickwick Plaza, Greenwich, CT 06830',
+    Title:         'Activity Statement',
+    Period:        'January 1, 2025 - December 31, 2025',
+    WhenGenerated: '2026-01-15 10:00:00',
+  }
+  const values = { ...defaults, ...overrides }
+  return Object.entries(values).map(([key, val]) => ['Statement', 'Data', key, val])
+}
+
+function makeAccountRows(overrides = {}) {
+  const defaults = {
+    Name:           'John Doe',
+    Account:        'U1234567',
+    'Account Type': 'Individual',
+    'Customer Type': 'Individual',
+    Capabilities:  'Trading',
+    'Base Currency': 'USD',
+  }
+  const values = { ...defaults, ...overrides }
+  return Object.entries(values).map(([key, val]) => ['Account Information', 'Data', key, val])
+}
+
+describe('parseStatementInfo', () => {
+  it('extracts all statement fields correctly', () => {
+    const rows = makeStatementRows()
+    const { statement } = parseStatementInfo(rows)
+    expect(statement).toMatchObject({
+      brokerName:    'Interactive Brokers LLC',
+      brokerAddress: '1 Pickwick Plaza, Greenwich, CT 06830',
+      title:         'Activity Statement',
+      period:        'January 1, 2025 - December 31, 2025',
+      generatedAt:   '2026-01-15 10:00:00',
+    })
+  })
+
+  it('extracts all account fields correctly', () => {
+    const rows = makeAccountRows()
+    const { account } = parseStatementInfo(rows)
+    expect(account).toMatchObject({
+      name:         'John Doe',
+      accountId:    'U1234567',
+      accountType:  'Individual',
+      customerType: 'Individual',
+      capabilities: 'Trading',
+      baseCurrency: 'USD',
+    })
+  })
+
+  it('returns empty strings for missing statement fields', () => {
+    const { statement } = parseStatementInfo([])
+    expect(statement.brokerName).toBe('')
+    expect(statement.period).toBe('')
+    expect(statement.generatedAt).toBe('')
+  })
+
+  it('returns empty strings for missing account fields', () => {
+    const { account } = parseStatementInfo([])
+    expect(account.name).toBe('')
+    expect(account.accountId).toBe('')
+    expect(account.baseCurrency).toBe('')
+  })
+
+  it('ignores rows from other sections', () => {
+    const rows = [
+      ...makeStatementRows(),
+      ['Trades', 'Data', 'BrokerName', 'Should be ignored'],
+    ]
+    const { statement } = parseStatementInfo(rows)
+    expect(statement.brokerName).toBe('Interactive Brokers LLC')
+  })
+
+  it('trims whitespace from values', () => {
+    const rows = [['Statement', 'Data', 'BrokerName', '  Interactive Brokers LLC  ']]
+    const { statement } = parseStatementInfo(rows)
+    expect(statement.brokerName).toBe('Interactive Brokers LLC')
+  })
+
+  it('parses mixed statement and account rows together', () => {
+    const rows = [...makeStatementRows(), ...makeAccountRows()]
+    const { statement, account } = parseStatementInfo(rows)
+    expect(statement.brokerName).toBe('Interactive Brokers LLC')
+    expect(account.accountId).toBe('U1234567')
+  })
+})

--- a/src/domain/parser/__tests__/parseTaxYear.test.js
+++ b/src/domain/parser/__tests__/parseTaxYear.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { parseTaxYear } from '../parseTaxYear.js'
+
+describe('parseTaxYear', () => {
+  it('extracts year from standard IBKR period format', () => {
+    expect(parseTaxYear('January 1, 2025 - December 31, 2025')).toBe(2025)
+  })
+
+  it('extracts year for future supported years', () => {
+    expect(parseTaxYear('January 1, 2026 - December 31, 2026')).toBe(2026)
+    expect(parseTaxYear('January 1, 2030 - December 31, 2030')).toBe(2030)
+  })
+
+  it('uses the trailing year (end of period)', () => {
+    // The regex matches the last 4-digit number
+    expect(parseTaxYear('January 1, 2025 - December 31, 2025')).toBe(2025)
+  })
+
+  it('throws for year before 2025', () => {
+    expect(() => parseTaxYear('January 1, 2024 - December 31, 2024')).toThrow()
+    expect(() => parseTaxYear('January 1, 2023 - December 31, 2023')).toThrow()
+  })
+
+  it('throws an error containing the unsupported year', () => {
+    expect(() => parseTaxYear('January 1, 2024 - December 31, 2024')).toThrow('2024')
+  })
+
+  it('throws for unrecognized format', () => {
+    expect(() => parseTaxYear('invalid period')).toThrow()
+    expect(() => parseTaxYear('')).toThrow()
+    expect(() => parseTaxYear(null)).toThrow()
+    expect(() => parseTaxYear(undefined)).toThrow()
+  })
+
+  it('throws error with Bulgarian message for unsupported year', () => {
+    expect(() => parseTaxYear('January 1, 2020 - December 31, 2020')).toThrow(
+      /не се поддържа/
+    )
+  })
+
+  it('throws error with Bulgarian message for unrecognized format', () => {
+    expect(() => parseTaxYear('bad format')).toThrow(/Неразпознат формат/)
+  })
+})

--- a/src/pipeline/__tests__/calculate.test.js
+++ b/src/pipeline/__tests__/calculate.test.js
@@ -1,0 +1,384 @@
+import { describe, it, expect } from 'vitest'
+import { calculate } from '../calculate.js'
+
+// EUR uses a fixed rate (1.95583) — ideal for deterministic tests with exact math
+const EUR_BGN = 1.95583
+
+function makeInput(overrides = {}) {
+  return {
+    taxYear:      2025,
+    instruments:  [],
+    csvTrades:    [],
+    trades:       [],
+    openPositions: [],
+    dividends:    [],
+    withholdingTax: [],
+    interest:     [],
+    ...overrides,
+  }
+}
+
+function makeTrade(fields = {}) {
+  return {
+    symbol:     fields.symbol     ?? 'AAPL',
+    datetime:   fields.datetime   ?? '2025-03-15, 10:00:00',
+    settleDate: fields.settleDate ?? '2025-03-17',
+    exchange:   fields.exchange   ?? 'NASDAQ',
+    currency:   fields.currency   ?? 'EUR',
+    side:       fields.side       ?? 'BUY',
+    quantity:   fields.quantity   ?? '10',
+    price:      fields.price      ?? '150.00',
+    proceeds:   fields.proceeds   ?? '-1500.00',
+    commission: fields.commission ?? '-5.00',
+    fee:        fields.fee        ?? '0',
+    orderType:  fields.orderType  ?? 'LMT',
+    code:       fields.code       ?? 'O',
+  }
+}
+
+describe('calculate — return structure', () => {
+  it('returns all top-level result keys for empty input', () => {
+    const result = calculate(makeInput())
+    expect(result).toHaveProperty('trades')
+    expect(result).toHaveProperty('holdings')
+    expect(result).toHaveProperty('dividends')
+    expect(result).toHaveProperty('interest')
+    expect(result).toHaveProperty('taxSummary')
+    expect(result).toHaveProperty('taxYear')
+    expect(result).toHaveProperty('localCurrencyCode')
+    expect(result).toHaveProperty('localCurrencyLabel')
+  })
+
+  it('reports taxYear and localCurrency correctly for 2025', () => {
+    const result = calculate(makeInput({ taxYear: 2025 }))
+    expect(result.taxYear).toBe(2025)
+    expect(result.localCurrencyCode).toBe('BGN')
+    expect(result.localCurrencyLabel).toBe('лв')
+  })
+
+  it('reports EUR local currency for 2026', () => {
+    const result = calculate(makeInput({ taxYear: 2026 }))
+    expect(result.localCurrencyCode).toBe('EUR')
+    expect(result.localCurrencyLabel).toBe('евро')
+  })
+
+  it('taxSummary has app5, app13, app8Holdings, app8Dividends', () => {
+    const result = calculate(makeInput())
+    expect(result.taxSummary).toHaveProperty('app5')
+    expect(result.taxSummary).toHaveProperty('app13')
+    expect(result.taxSummary).toHaveProperty('app8Holdings')
+    expect(result.taxSummary).toHaveProperty('app8Dividends')
+  })
+
+  it('trades result has columns and rows arrays', () => {
+    const result = calculate(makeInput())
+    expect(Array.isArray(result.trades.columns)).toBe(true)
+    expect(Array.isArray(result.trades.rows)).toBe(true)
+  })
+})
+
+describe('calculate — BUY accumulates cost basis', () => {
+  it('BUY row has taxable=null and taxExemptLabel=""', () => {
+    const input = makeInput({
+      trades: [makeTrade({ side: 'BUY', quantity: '10', proceeds: '-1500', commission: '-5', fee: '0' })],
+    })
+    const { trades } = calculate(input)
+    const buyRow = trades.rows.find(r => r.side === 'BUY')
+    expect(buyRow.taxable).toBeNull()
+    expect(buyRow.taxExemptLabel).toBe('')
+  })
+
+  it('BUY row has correct proceeds, commission and totalWithFee', () => {
+    const input = makeInput({
+      trades: [makeTrade({ side: 'BUY', quantity: '10', proceeds: '-1500', commission: '-5', fee: '0' })],
+    })
+    const { trades } = calculate(input)
+    const buyRow = trades.rows.find(r => r.side === 'BUY')
+    expect(buyRow.proceeds).toBeCloseTo(-1500)
+    expect(buyRow.commission).toBeCloseTo(-5)
+    expect(buyRow.totalWithFee).toBeCloseTo(-1505)
+  })
+
+  it('BUY totalWithFeeBGN = totalWithFee * EUR_BGN for EUR trades', () => {
+    const input = makeInput({
+      trades: [makeTrade({ side: 'BUY', quantity: '10', proceeds: '-1500', commission: '-5', fee: '0' })],
+    })
+    const { trades } = calculate(input)
+    const buyRow = trades.rows.find(r => r.side === 'BUY')
+    expect(buyRow.totalWithFeeBGN).toBeCloseTo(-1505 * EUR_BGN, 2)
+  })
+})
+
+describe('calculate — SELL realizes gain/loss', () => {
+  it('SELL after BUY produces correct costBasis', () => {
+    const input = makeInput({
+      trades: [
+        makeTrade({ side: 'BUY',  quantity: '10',  proceeds: '-1500', commission: '-5',  fee: '0', datetime: '2025-03-15, 10:00:00' }),
+        makeTrade({ side: 'SELL', quantity: '-10', proceeds: '1800',  commission: '-5',  fee: '0', datetime: '2025-06-15, 10:00:00' }),
+      ],
+    })
+    const { trades } = calculate(input)
+    const sellRow = trades.rows.find(r => r.side === 'SELL')
+    expect(sellRow.costBasis).toBeCloseTo(1505, 2)
+    expect(sellRow.costBasisBGN).toBeCloseTo(1505 * EUR_BGN, 2)
+  })
+
+  it('SELL proceedsBGN = totalWithFee * EUR_BGN for EUR trades', () => {
+    const input = makeInput({
+      trades: [
+        makeTrade({ side: 'BUY',  quantity: '10',  proceeds: '-1500', commission: '-5',  fee: '0', datetime: '2025-03-15, 10:00:00' }),
+        makeTrade({ side: 'SELL', quantity: '-10', proceeds: '1800',  commission: '-5',  fee: '0', datetime: '2025-06-15, 10:00:00' }),
+      ],
+    })
+    const { trades } = calculate(input)
+    const sellRow = trades.rows.find(r => r.side === 'SELL')
+    // totalWithFee = 1800 + (-5) + 0 = 1795
+    expect(sellRow.proceedsBGN).toBeCloseTo(1795 * EUR_BGN, 2)
+  })
+
+  it('profit trade appears in app5 when exchange is not EU-regulated', () => {
+    const input = makeInput({
+      trades: [
+        makeTrade({ side: 'BUY',  quantity: '10',  proceeds: '-1500', commission: '-5',  fee: '0', datetime: '2025-03-15, 10:00:00', exchange: 'NASDAQ' }),
+        makeTrade({ side: 'SELL', quantity: '-10', proceeds: '1800',  commission: '-5',  fee: '0', datetime: '2025-06-15, 10:00:00', exchange: 'NASDAQ' }),
+      ],
+    })
+    const { taxSummary } = calculate(input)
+    expect(taxSummary.app5.profits).toBeGreaterThan(0)
+    expect(taxSummary.app13.profits).toBe(0)
+  })
+
+  it('loss trade contributes to app5.losses', () => {
+    const input = makeInput({
+      trades: [
+        makeTrade({ side: 'BUY',  quantity: '10',  proceeds: '-1800', commission: '-5', fee: '0', datetime: '2025-03-15, 10:00:00', exchange: 'NASDAQ' }),
+        makeTrade({ side: 'SELL', quantity: '-10', proceeds: '1500',  commission: '-5', fee: '0', datetime: '2025-06-15, 10:00:00', exchange: 'NASDAQ' }),
+      ],
+    })
+    const { taxSummary } = calculate(input)
+    expect(taxSummary.app5.losses).toBeGreaterThan(0)
+    expect(taxSummary.app5.profits).toBe(0)
+  })
+
+  it('SELL row is taxable=true for non-EU stock', () => {
+    const input = makeInput({
+      trades: [
+        makeTrade({ side: 'BUY',  quantity: '10',  proceeds: '-1500', commission: '-5', fee: '0', datetime: '2025-03-15, 10:00:00', exchange: 'NASDAQ' }),
+        makeTrade({ side: 'SELL', quantity: '-10', proceeds: '1800',  commission: '-5', fee: '0', datetime: '2025-06-15, 10:00:00', exchange: 'NASDAQ' }),
+      ],
+    })
+    const { trades } = calculate(input)
+    const sellRow = trades.rows.find(r => r.side === 'SELL')
+    expect(sellRow.taxable).toBe(true)
+    expect(sellRow.taxExemptLabel).toBe('Облагаем')
+  })
+})
+
+describe('calculate — tax-exempt ETF on EU-regulated exchange', () => {
+  // EXS1 (iShares Core MSCI World ETF) on IBIS (Deutsche Börse Xetra)
+  const etfInstruments = [
+    {
+      assetCategory: 'ETF', symbol: 'EXS1', description: 'iShares Core MSCI World ETF',
+      conid: '123', securityId: 'IE00B4L5Y983', underlying: '',
+      listingExchange: 'IBIS', multiplier: '1', type: 'ETF', code: '',
+    },
+  ]
+
+  it('ETF sell on EU-regulated exchange is taxable=false', () => {
+    const input = makeInput({
+      instruments: etfInstruments,
+      trades: [
+        makeTrade({ symbol: 'EXS1', side: 'BUY',  quantity: '5',  proceeds: '-750',  commission: '-2', fee: '0', datetime: '2025-03-15, 10:00:00', exchange: 'IBIS' }),
+        makeTrade({ symbol: 'EXS1', side: 'SELL', quantity: '-5', proceeds: '900',   commission: '-2', fee: '0', datetime: '2025-06-15, 10:00:00', exchange: 'IBIS' }),
+      ],
+    })
+    const { trades } = calculate(input)
+    const sellRow = trades.rows.find(r => r.side === 'SELL')
+    expect(sellRow.taxable).toBe(false)
+    expect(sellRow.taxExemptLabel).toBe('Освободен')
+  })
+
+  it('exempt ETF sell contributes to app13, not app5', () => {
+    const input = makeInput({
+      instruments: etfInstruments,
+      trades: [
+        makeTrade({ symbol: 'EXS1', side: 'BUY',  quantity: '5',  proceeds: '-750',  commission: '-2', fee: '0', datetime: '2025-03-15, 10:00:00', exchange: 'IBIS' }),
+        makeTrade({ symbol: 'EXS1', side: 'SELL', quantity: '-5', proceeds: '900',   commission: '-2', fee: '0', datetime: '2025-06-15, 10:00:00', exchange: 'IBIS' }),
+      ],
+    })
+    const { taxSummary } = calculate(input)
+    expect(taxSummary.app13.profits).toBeGreaterThan(0)
+    expect(taxSummary.app5.profits).toBe(0)
+  })
+
+  it('non-ETF stock on EU exchange is still taxable', () => {
+    // Regular stock (not ETF) on Frankfurt — must be taxable regardless
+    const input = makeInput({
+      instruments: [
+        { assetCategory: 'Stocks', symbol: 'SAP', description: 'SAP SE', conid: '456',
+          securityId: 'DE0007164600', underlying: '', listingExchange: 'FWB',
+          multiplier: '1', type: 'COMMON', code: '' },
+      ],
+      trades: [
+        makeTrade({ symbol: 'SAP', side: 'BUY',  quantity: '5',  proceeds: '-500', commission: '-2', fee: '0', datetime: '2025-03-15, 10:00:00', exchange: 'FWB' }),
+        makeTrade({ symbol: 'SAP', side: 'SELL', quantity: '-5', proceeds: '600',  commission: '-2', fee: '0', datetime: '2025-06-15, 10:00:00', exchange: 'FWB' }),
+      ],
+    })
+    const { trades } = calculate(input)
+    const sellRow = trades.rows.find(r => r.side === 'SELL')
+    expect(sellRow.taxable).toBe(true)
+  })
+})
+
+describe('calculate — weighted-average cost basis', () => {
+  it('averages cost across multiple BUY lots', () => {
+    const input = makeInput({
+      trades: [
+        makeTrade({ side: 'BUY',  quantity: '10', proceeds: '-1000', commission: '0', fee: '0', datetime: '2025-01-15, 10:00:00' }),
+        makeTrade({ side: 'BUY',  quantity: '10', proceeds: '-2000', commission: '0', fee: '0', datetime: '2025-02-15, 10:00:00' }),
+        // SELL 10 units: avg cost = (1000+2000)/20 * 10 = 1500
+        makeTrade({ side: 'SELL', quantity: '-10', proceeds: '1800', commission: '0', fee: '0', datetime: '2025-06-15, 10:00:00' }),
+      ],
+    })
+    const { trades } = calculate(input)
+    const sellRow = trades.rows.find(r => r.side === 'SELL')
+    expect(sellRow.costBasis).toBeCloseTo(1500, 2)
+  })
+})
+
+describe('calculate — prior-year positions', () => {
+  it('uses prior-year costBGN when seeded via priorPositions', () => {
+    const priorPositions = [
+      { symbol: 'AAPL', qty: 10, costUSD: 1500, costBGN: 2800 },
+    ]
+    const input = makeInput({
+      trades: [
+        makeTrade({ side: 'SELL', quantity: '-10', proceeds: '1800', commission: '-5', fee: '0', datetime: '2025-06-15, 10:00:00' }),
+      ],
+    })
+    const { trades } = calculate(input, priorPositions)
+    const sellRow = trades.rows.find(r => r.side === 'SELL')
+    // Prior positions seeded cost = 1500, costBGN = 2800
+    // SELL 10 of 10: costBasis = 1500, costBasisBGN = 2800
+    expect(sellRow.costBasis).toBeCloseTo(1500, 2)
+    expect(sellRow.costBasisBGN).toBeCloseTo(2800, 2)
+  })
+})
+
+describe('calculate — dividends', () => {
+  it('matches dividends with withholding tax by symbol and date', () => {
+    const input = makeInput({
+      instruments: [
+        { assetCategory: 'Stocks', symbol: 'AAPL', description: 'Apple Inc', conid: '1',
+          securityId: 'US0378331005', underlying: '', listingExchange: 'NASDAQ',
+          multiplier: '1', type: 'COMMON', code: '' },
+      ],
+      dividends: [
+        // gross 100 USD → BG tax = 100 * 0.05 = 5 USD; withholding 1.5 < 5 → dueTaxBGN > 0
+        { currency: 'USD', date: '2025-03-15', description: 'AAPL(US0378331005) Cash Dividend', amount: '100.00' },
+      ],
+      withholdingTax: [
+        { currency: 'USD', date: '2025-03-15', description: 'AAPL(US0378331005) Cash Dividend', amount: '-1.50', code: 'Po' },
+      ],
+    })
+    const { dividends, taxSummary } = calculate(input)
+    expect(dividends.rows).toHaveLength(1)
+    expect(dividends.rows[0].symbol).toBe('AAPL')
+    expect(dividends.rows[0].grossAmount).toBeCloseTo(100)
+    expect(dividends.rows[0].withheldTax).toBeCloseTo(1.5)
+    expect(dividends.rows[0].netAmount).toBeCloseTo(98.5)
+
+    // App8 dividends should have exactly one row
+    expect(taxSummary.app8Dividends.rows).toHaveLength(1)
+    expect(taxSummary.app8Dividends.rows[0].dueTaxBGN).toBeGreaterThan(0)
+  })
+
+  it('taxCode=3 when no withholding tax (credit exemption method)', () => {
+    const input = makeInput({
+      dividends: [
+        { currency: 'USD', date: '2025-03-15', description: 'AAPL Cash Dividend', amount: '10.00' },
+      ],
+      withholdingTax: [],
+    })
+    const { dividends } = calculate(input)
+    expect(dividends.rows[0].taxCode).toBe(3)
+  })
+
+  it('taxCode=1 when withholding tax exists', () => {
+    const input = makeInput({
+      dividends: [
+        { currency: 'USD', date: '2025-03-15', description: 'AAPL(X) Cash Dividend', amount: '10.00' },
+      ],
+      withholdingTax: [
+        { currency: 'USD', date: '2025-03-15', description: 'AAPL(X) Cash Dividend', amount: '-1.50', code: 'Po' },
+      ],
+    })
+    const { dividends } = calculate(input)
+    expect(dividends.rows[0].taxCode).toBe(1)
+  })
+})
+
+describe('calculate — interest', () => {
+  it('converts interest amounts to local currency', () => {
+    const input = makeInput({
+      interest: [
+        { currency: 'EUR', date: '2025-02-28', description: 'EUR Credit Interest', amount: '10.00' },
+      ],
+    })
+    const { interest } = calculate(input)
+    const dataRow = interest.rows.find(r => !r._total)
+    expect(dataRow.amount).toBeCloseTo(10)
+    expect(dataRow.amountBGN).toBeCloseTo(10 * EUR_BGN, 2)
+  })
+
+  it('adds total rows for each currency and a BGN grand total', () => {
+    const input = makeInput({
+      interest: [
+        { currency: 'EUR', date: '2025-01-31', description: 'EUR Interest', amount: '5.00' },
+        { currency: 'EUR', date: '2025-02-28', description: 'EUR Interest', amount: '3.00' },
+      ],
+    })
+    const { interest } = calculate(input)
+    const eurTotal = interest.rows.find(r => r._total && r.currency === 'EUR')
+    const bgnTotal = interest.rows.find(r => r._total && r.currency === 'BGN')
+    expect(eurTotal).toBeDefined()
+    expect(eurTotal.amount).toBeCloseTo(8)
+    expect(bgnTotal).toBeDefined()
+  })
+})
+
+describe('calculate — edge cases', () => {
+  it('handles completely empty input without throwing', () => {
+    expect(() => calculate(makeInput())).not.toThrow()
+  })
+
+  it('handles SELL with no prior BUY in dataset (falls back to csvTradeBasis)', () => {
+    // When there's no BUY in current year's trades, costBasis should be null
+    // unless csvTradeBasis has an entry
+    const input = makeInput({
+      trades: [
+        makeTrade({ side: 'SELL', quantity: '-10', proceeds: '1800', commission: '-5', fee: '0',
+                    datetime: '2025-06-15, 10:00:00', symbol: 'ORPHAN' }),
+      ],
+    })
+    const { trades } = calculate(input)
+    const sellRow = trades.rows.find(r => r.side === 'SELL')
+    // No prior BUY and no csvTradeBasis entry — costBasis should be null
+    expect(sellRow.costBasis).toBeNull()
+  })
+
+  it('handles trades for multiple symbols independently', () => {
+    const input = makeInput({
+      trades: [
+        makeTrade({ symbol: 'AAPL', side: 'BUY',  quantity: '10',  proceeds: '-1500', commission: '-5', fee: '0', datetime: '2025-03-15, 10:00:00' }),
+        makeTrade({ symbol: 'MSFT', side: 'BUY',  quantity: '5',   proceeds: '-500',  commission: '-2', fee: '0', datetime: '2025-03-20, 10:00:00' }),
+        makeTrade({ symbol: 'AAPL', side: 'SELL', quantity: '-10', proceeds: '1800',  commission: '-5', fee: '0', datetime: '2025-06-15, 10:00:00' }),
+      ],
+    })
+    const { trades, taxSummary } = calculate(input)
+    const aaplSell = trades.rows.find(r => r.side === 'SELL' && r.symbol === 'AAPL')
+    expect(aaplSell.costBasis).toBeCloseTo(1505, 2)
+    // MSFT BUY should not affect AAPL cost basis
+    expect(taxSummary.app5.profits).toBeGreaterThan(0)
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,4 +8,8 @@ export default defineConfig({
     react(),
     babel({ presets: [reactCompilerPreset()] })
   ],
+  test: {
+    environment: 'node',
+    globals: true,
+  },
 })


### PR DESCRIPTION
- Install vitest and configure it via vite.config.js (test environment: node, globals: true)
- Add npm test / test:watch scripts to package.json
- 116 tests across 9 test files covering:
  - parseDividends / parseWithholdingTax
  - parseInterest
  - parseStatementInfo
  - parseTaxYear (including Bulgarian error messages)
  - parseInstruments / buildInstrumentInfo / expandByAliases
  - parseCsvTrades / buildCsvTradeBasis
  - parseOpenPositions / buildOpenPositions
  - buildTradeTotals / buildTaxSummary
  - calculate() — BUY/SELL cost basis, tax-exempt ETF logic,
    weighted-average, prior-year positions, dividends, interest, edge cases

https://claude.ai/code/session_01FpSDEu6Bv3sQegTnYdSfM7