### PR TITLE
Detect ETF from type field when name lacks "ETF" keyword

### DIFF
--- a/src/domain/__tests__/classifier.test.js
+++ b/src/domain/__tests__/classifier.test.js
@@ -9,6 +9,17 @@ describe('classifyInstrument', () => {
     expect(c.isRegulatedMarket).toBe(true)
   })
 
+  it('detects ETF from type field when name has no "ETF" (e.g. IWDA)', () => {
+    const c = classifyInstrument({ name: 'ISHARES CORE MSCI WORLD', type: 'ETF', isRegulatedMarket: true })
+    expect(c.isETF).toBe(true)
+    expect(c.isCryptoRelated).toBe(false)
+  })
+
+  it('does not treat non-ETF type as ETF', () => {
+    const c = classifyInstrument({ name: 'SAP SE', type: 'COMMON', isRegulatedMarket: true })
+    expect(c.isETF).toBe(false)
+  })
+
   it('detects crypto ETF — BITCOIN in name', () => {
     const c = classifyInstrument({ name: 'iShares Bitcoin Trust ETF', isRegulatedMarket: true })
     expect(c.isETF).toBe(true)
@@ -51,6 +62,11 @@ describe('classifyInstrument', () => {
 describe('isTaxable', () => {
   it('standard ETF on regulated market → необлагаем (false)', () => {
     expect(isTaxable({ name: 'iShares Core MSCI World ETF', isRegulatedMarket: true })).toBe(false)
+  })
+
+  it('ETF detected by type (no "ETF" in name) on regulated market → необлагаем (false)', () => {
+    // IWDA: description = "ISHARES CORE MSCI WORLD", type = "ETF", exchange = IBIS2 (regulated)
+    expect(isTaxable({ name: 'ISHARES CORE MSCI WORLD', type: 'ETF', isRegulatedMarket: true })).toBe(false)
   })
 
   it('crypto ETF on regulated market → облагаем (true)', () => {

--- a/src/domain/instrument/classifier.js
+++ b/src/domain/instrument/classifier.js
@@ -4,7 +4,7 @@
 export function classifyInstrument(instrument) {
   const name = (instrument.name || '').toUpperCase()
 
-  const isETF = name.includes('ETF')
+  const isETF = name.includes('ETF') || (instrument.type || '').toUpperCase() === 'ETF'
   const isCryptoRelated =
     name.includes('BITCOIN') ||
     name.includes('CRYPTO') ||

--- a/src/pipeline/__tests__/calculate.test.js
+++ b/src/pipeline/__tests__/calculate.test.js
@@ -228,6 +228,47 @@ describe('calculate — tax-exempt ETF on EU-regulated exchange', () => {
     const sellRow = trades.rows.find(r => r.side === 'SELL')
     expect(sellRow.taxable).toBe(true)
   })
+
+  it('IWDA ETF (type=ETF, no "ETF" in description) on IBIS2 is taxable=false', () => {
+    // Regression: IWDA description = "ISHARES CORE MSCI WORLD" — no "ETF" in name.
+    // Must be detected as ETF via the type field from Financial Instrument Information.
+    const input = makeInput({
+      instruments: [
+        {
+          assetCategory: 'Stocks', symbol: 'IWDA', description: 'ISHARES CORE MSCI WORLD',
+          conid: '100292038', securityId: 'IE00B4L5Y983', underlying: '',
+          listingExchange: 'AEB', multiplier: '1', type: 'ETF', code: '',
+        },
+      ],
+      trades: [
+        makeTrade({ symbol: 'IWDA', side: 'BUY',  quantity: '10', proceeds: '-1110', commission: '-1.32', fee: '0', datetime: '2025-08-01, 10:00:00', exchange: 'IBIS2' }),
+        makeTrade({ symbol: 'IWDA', side: 'SELL', quantity: '-10', proceeds: '1110', commission: '-1.32', fee: '0', datetime: '2025-11-10, 04:17:39', exchange: 'IBIS2' }),
+      ],
+    })
+    const { trades } = calculate(input)
+    const sellRow = trades.rows.find(r => r.side === 'SELL')
+    expect(sellRow.taxable).toBe(false)
+    expect(sellRow.taxExemptLabel).toBe('Освободен')
+  })
+
+  it('IWDA ETF sell on IBIS2 contributes to app13, not app5', () => {
+    const input = makeInput({
+      instruments: [
+        {
+          assetCategory: 'Stocks', symbol: 'IWDA', description: 'ISHARES CORE MSCI WORLD',
+          conid: '100292038', securityId: 'IE00B4L5Y983', underlying: '',
+          listingExchange: 'AEB', multiplier: '1', type: 'ETF', code: '',
+        },
+      ],
+      trades: [
+        makeTrade({ symbol: 'IWDA', side: 'BUY',  quantity: '10', proceeds: '-1000', commission: '-1', fee: '0', datetime: '2025-08-01, 10:00:00', exchange: 'IBIS2' }),
+        makeTrade({ symbol: 'IWDA', side: 'SELL', quantity: '-10', proceeds: '1200', commission: '-1', fee: '0', datetime: '2025-11-10, 04:17:39', exchange: 'IBIS2' }),
+      ],
+    })
+    const { taxSummary } = calculate(input)
+    expect(taxSummary.app13.profits).toBeGreaterThan(0)
+    expect(taxSummary.app5.profits).toBe(0)
+  })
 })
 
 describe('calculate — weighted-average cost basis', () => {

--- a/src/pipeline/calculate.js
+++ b/src/pipeline/calculate.js
@@ -24,6 +24,7 @@ function makeInstrument(trade, instrumentInfo) {
   const exch = IBKR_EXCHANGES[trade.exchange]
   return {
     name: info?.description ?? '',
+    type: info?.type ?? '',
     isRegulatedMarket: exch?.regulated ?? false,
   }
 }


### PR DESCRIPTION
## Summary
This PR fixes ETF detection for instruments like IWDA that have `type: 'ETF'` in their financial instrument information but don't include the word "ETF" in their description (e.g., "ISHARES CORE MSCI WORLD"). Previously, these were incorrectly classified as taxable securities.

## Key Changes
- **classifier.js**: Updated `classifyInstrument()` to detect ETFs by checking both the name field AND the `type` field from instrument metadata
- **calculate.js**: Added `type` field to the instrument object passed to classification logic
- **Tests**: Added comprehensive test coverage for:
  - ETF detection via type field when name lacks "ETF"
  - Verification that non-ETF types are not misclassified
  - Tax-exempt status for IWDA on IBIS2 exchange
  - Correct tax form assignment (app13 for tax-exempt ETF gains, not app5)

## Implementation Details
The fix is minimal and focused: the classifier now checks `instrument.type === 'ETF'` as a fallback when the name doesn't contain "ETF". This leverages the existing financial instrument metadata from Interactive Brokers without requiring changes to the tax logic or exchange detection.

https://claude.ai/code/session_01HWqant9hPDwDyNaTR5n9o2