### PR TITLE
feat: always show CostBasisStrategySelector when files are loaded

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -284,20 +284,22 @@ export default function App() {
 
           {/* Prior-year positions form — shown when inferred positions exist */}
           {!result && pendingPositions !== null && pendingPositions.length > 0 && (
-              <>
-                <PriorYearPositionsForm
-                  positions={pendingPositions}
-                  onPositionChange={(i, field, value) =>
-                  setPendingPositions(prev => prev.map((p, idx) => idx === i ? { ...p, [field]: value } : p))
-                  }
-                  taxYear={taxYear}
-                />
-                <CostBasisStrategySelector
-                  value={costBasisStrategy}
-                  onChange={setCostBasisStrategy}
-                />
-              </>
+              <PriorYearPositionsForm
+                positions={pendingPositions}
+                onPositionChange={(i, field, value) =>
+                setPendingPositions(prev => prev.map((p, idx) => idx === i ? { ...p, [field]: value } : p))
+                }
+                taxYear={taxYear}
+              />
             )}
+
+          {/* Cost basis strategy — shown whenever files are loaded */}
+          {!result && inputData && (
+            <CostBasisStrategySelector
+              value={costBasisStrategy}
+              onChange={setCostBasisStrategy}
+            />
+          )}
 
           {/* Demo load button — shown until files are selected */}
             {(!csvFile || !htmlFile) && (


### PR DESCRIPTION
Previously the selector was hidden when no prior-year positions were
inferred (empty pendingPositions). Now it renders independently
whenever inputData is available, so users can always choose their
cost-basis strategy regardless of whether they have carry-over positions.

https://claude.ai/code/session_01EdR4chNL6SVRXX4dHLjf6w