### PR TITLE
fix: цена на придобиване always showing 0 due to key casing typo

### DIFF
--- a/src/domain/__tests__/tradeSummary.test.js
+++ b/src/domain/__tests__/tradeSummary.test.js
@@ -157,6 +157,6 @@ describe('buildTaxSummary', () => {
     ]
     const { sumTaxable } = buildTaxSummary(rows)
     expect(sumTaxable.totalProceedsLcl).toBeCloseTo(500)
-    expect(sumTaxable.totalcostBasisLcl).toBeCloseTo(350)
+    expect(sumTaxable.totalCostBasisLcl).toBeCloseTo(350)
   })
 })

--- a/src/domain/tradeSummary.js
+++ b/src/domain/tradeSummary.js
@@ -51,7 +51,7 @@ export function buildTaxSummary(dataRows) {
     }, 0)
     return {
       totalProceedsLcl:  group.reduce((s, r) => s + (r.totalWithFeeLcl ?? 0), 0),
-      totalcostBasisLcl: group.reduce((s, r) => s + (r.costBasisLcl    ?? 0), 0),
+      totalCostBasisLcl: group.reduce((s, r) => s + (r.costBasisLcl    ?? 0), 0),
       profits,
       losses,
     }


### PR DESCRIPTION
buildTaxSummary returned totalcostBasisLcl (lowercase 'c') while
TradeSummaryPresenter read totalCostBasisLcl (uppercase 'C'), causing
the acquisition cost total to be undefined → 0 in both App5 and App13.

https://claude.ai/code/session_0113NhwzWehbv3AL7Qu56nyS