### PR TITLE
Add "Копирай в Excel" button to ResultTabs (closes #28)

### DIFF
--- a/src/i18n/locales/bg.json
+++ b/src/i18n/locales/bg.json
@@ -147,8 +147,12 @@
       "positions": "Позиции",
       "dividends": "Дивиденти",
       "interest": "Лихви",
-      "dev": "Dev"
+      "dev": "Dev",
+      "summary": "Обобщение"
     },
+    "copyExcel": "Копирай в Excel",
+    "copyExcelDone": "Копирано",
+    "copyExcelError": "Грешка при копиране",
     "tradesTableTitle": "Trade Confirmation – Сделки",
     "countLabel": {
       "trades": "сделки",

--- a/src/i18n/locales/bg.json
+++ b/src/i18n/locales/bg.json
@@ -153,6 +153,7 @@
     "copyExcel": "Копирай в Excel",
     "copyExcelDone": "Копирано",
     "copyExcelError": "Грешка при копиране",
+    "copyExcelTooltip": "Копира данните от всички раздели",
     "tradesTableTitle": "Trade Confirmation – Сделки",
     "countLabel": {
       "trades": "сделки",

--- a/src/presentation/ExcelPresenter.js
+++ b/src/presentation/ExcelPresenter.js
@@ -1,0 +1,79 @@
+import { TradePresenter } from './TradePresenter.js'
+import { HoldingPresenter } from './HoldingPresenter.js'
+import { DividendPresenter } from './DividendPresenter.js'
+import { InterestPresenter } from './InterestPresenter.js'
+import { TradeSummaryPresenter } from './TradeSummaryPresenter.js'
+
+function cellText(col, value) {
+  if (value == null) return col.nullAs ?? ''
+  if (col.decimals !== undefined && typeof value === 'number')
+    return value.toFixed(col.decimals)
+  return String(value)
+}
+
+function buildSection(name, columns, rows) {
+  const header = columns.map(c => c.shortLabel ?? c.label).join('\t')
+  const body = rows.map(row => columns.map(col => cellText(col, row[col.key])).join('\t'))
+  return [name, header, ...body].join('\n')
+}
+
+export class ExcelPresenter {
+  constructor({ t, lcl }) {
+    this.t = t
+    this.lcl = lcl
+  }
+
+  buildTsv(result) {
+    const { t, lcl } = this
+    const sections = []
+
+    const tradePresenter = new TradePresenter({ lcl })
+    const trades = tradePresenter.buildTable(result.trades)
+    sections.push(buildSection(t('app.tabs.trades'), trades.columns, trades.rows))
+
+    const holdingPresenter = new HoldingPresenter({ lcl })
+    const holdings = holdingPresenter.buildHoldings(result.holdings)
+    sections.push(buildSection(t('app.tabs.positions'), holdings.columns, holdings.rows))
+
+    if (result.dividends.length > 0) {
+      const divPresenter = new DividendPresenter({ lcl })
+      const dividends = divPresenter.buildDividendsTable(result.dividends)
+      sections.push(buildSection(t('app.tabs.dividends'), dividends.columns, dividends.rows))
+    }
+
+    const realInterest = result.interest.filter(r => !r._total)
+    if (realInterest.length > 0) {
+      const intPresenter = new InterestPresenter({ lcl })
+      const interest = intPresenter.buildTable(result.interest)
+      sections.push(buildSection(t('app.tabs.interest'), interest.columns, interest.rows))
+    }
+
+    const summaryPresenter = new TradeSummaryPresenter({ t, lcl })
+    sections.push(this.#summarySection(result.taxSummary, summaryPresenter))
+
+    return sections.join('\n\n\n')
+  }
+
+  #summarySection(taxSummary, presenter) {
+    const taxable = presenter.buildTaxable(taxSummary.sumTaxable)
+    const exempt = presenter.buildExempt(taxSummary.sumExempt)
+    const lines = [this.t('app.tabs.summary')]
+
+    if (taxable?.rows?.length > 0) {
+      lines.push(taxable.title)
+      taxable.rows.forEach(r =>
+        lines.push(`${r.label}\t${typeof r.value === 'number' ? r.value.toFixed(2) : r.value ?? ''}`)
+      )
+    }
+
+    if (exempt?.rows?.length > 0) {
+      lines.push('')
+      lines.push(exempt.title)
+      exempt.rows.forEach(r =>
+        lines.push(`${r.label}\t${typeof r.value === 'number' ? r.value.toFixed(2) : r.value ?? ''}`)
+      )
+    }
+
+    return lines.join('\n')
+  }
+}

--- a/src/ui/ResultTabs/ExcelCopyButton.jsx
+++ b/src/ui/ResultTabs/ExcelCopyButton.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Button } from '@mui/material'
+import { Button, Tooltip } from '@mui/material'
 import { ContentCopyOutlined, CheckOutlined, ErrorOutlineOutlined } from '@mui/icons-material'
 import { ExcelPresenter } from '../../presentation/ExcelPresenter.js'
 
@@ -35,15 +35,17 @@ export default function ExcelCopyButton({ result }) {
   const color = status === 'ok' ? 'success' : status === 'error' ? 'error' : 'primary'
 
   return (
-    <Button
-      size="small"
-      variant="outlined"
-      color={color}
-      startIcon={icon}
-      onClick={handleCopy}
-      sx={{ ml: 1, mb: 0.5, whiteSpace: 'nowrap', alignSelf: 'flex-end', flexShrink: 0 }}
-    >
-      {label}
-    </Button>
+    <Tooltip title={t('app.copyExcelTooltip')} placement="left">
+      <Button
+        size="small"
+        variant="outlined"
+        color={color}
+        startIcon={icon}
+        onClick={handleCopy}
+        sx={{ whiteSpace: 'nowrap' }}
+      >
+        {label}
+      </Button>
+    </Tooltip>
   )
 }

--- a/src/ui/ResultTabs/ExcelCopyButton.jsx
+++ b/src/ui/ResultTabs/ExcelCopyButton.jsx
@@ -1,0 +1,49 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@mui/material'
+import { ContentCopyOutlined, CheckOutlined, ErrorOutlineOutlined } from '@mui/icons-material'
+import { ExcelPresenter } from '../../presentation/ExcelPresenter.js'
+
+const RESET_DELAY = 2500
+
+export default function ExcelCopyButton({ result }) {
+  const { t } = useTranslation()
+  const [status, setStatus] = useState('idle')
+
+  async function handleCopy() {
+    try {
+      const text = new ExcelPresenter({ t, lcl: result.localCurrencyLabel }).buildTsv(result)
+      await navigator.clipboard.writeText(text)
+      setStatus('ok')
+    } catch {
+      setStatus('error')
+    } finally {
+      setTimeout(() => setStatus('idle'), RESET_DELAY)
+    }
+  }
+
+  const label =
+    status === 'ok' ? t('app.copyExcelDone') :
+    status === 'error' ? t('app.copyExcelError') :
+    t('app.copyExcel')
+
+  const icon =
+    status === 'ok' ? <CheckOutlined fontSize="small" /> :
+    status === 'error' ? <ErrorOutlineOutlined fontSize="small" /> :
+    <ContentCopyOutlined fontSize="small" />
+
+  const color = status === 'ok' ? 'success' : status === 'error' ? 'error' : 'primary'
+
+  return (
+    <Button
+      size="small"
+      variant="outlined"
+      color={color}
+      startIcon={icon}
+      onClick={handleCopy}
+      sx={{ ml: 1, mb: 0.5, whiteSpace: 'nowrap', alignSelf: 'flex-end', flexShrink: 0 }}
+    >
+      {label}
+    </Button>
+  )
+}

--- a/src/ui/ResultTabs/ResultTabs.jsx
+++ b/src/ui/ResultTabs/ResultTabs.jsx
@@ -7,6 +7,7 @@ import HoldingsTab from './HoldingsTab'
 import DividendsTab from './DividendsTab'
 import InterestTab from './InterestTab'
 import DevTab from './DevTab'
+import ExcelCopyButton from './ExcelCopyButton'
 
 const DEV_MODE = import.meta.env.VITE_DEV_MODE === 'true'
 
@@ -39,17 +40,20 @@ export default function ResultTabs({ result, inputJsonText, outputJsonText }) {
 
   return (
     <Box sx={{ mt: 2 }}>
-      <Tabs
-        value={tab}
-        onChange={(_, v) => setTab(v)}
-        variant="scrollable"
-        scrollButtons="auto"
-        sx={{ borderBottom: 1, borderColor: 'divider' }}
-      >
-        {tabs.map((tItem, i) => (
-          <Tab key={i} label={tItem.label} />
-        ))}
-      </Tabs>
+      <Box sx={{ display: 'flex', alignItems: 'flex-end', borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs
+          value={tab}
+          onChange={(_, v) => setTab(v)}
+          variant="scrollable"
+          scrollButtons="auto"
+          sx={{ flex: 1 }}
+        >
+          {tabs.map((tItem, i) => (
+            <Tab key={i} label={tItem.label} />
+          ))}
+        </Tabs>
+        <ExcelCopyButton result={result} />
+      </Box>
 
       <TabPanel value={tab} index={TAB_TRADES}>
         <TradesTab result={result} />

--- a/src/ui/ResultTabs/ResultTabs.jsx
+++ b/src/ui/ResultTabs/ResultTabs.jsx
@@ -40,19 +40,34 @@ export default function ResultTabs({ result, inputJsonText, outputJsonText }) {
 
   return (
     <Box sx={{ mt: 2 }}>
-      <Box sx={{ display: 'flex', alignItems: 'flex-end', borderBottom: 1, borderColor: 'divider' }}>
+      <Box sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        alignItems: 'flex-end',
+        borderBottom: 1,
+        borderColor: 'divider',
+      }}>
         <Tabs
           value={tab}
           onChange={(_, v) => setTab(v)}
           variant="scrollable"
           scrollButtons="auto"
-          sx={{ flex: 1 }}
+          sx={{ flex: { xs: '0 0 100%', sm: 1 }, order: { xs: 2, sm: 1 } }}
         >
           {tabs.map((tItem, i) => (
             <Tab key={i} label={tItem.label} />
           ))}
         </Tabs>
-        <ExcelCopyButton result={result} />
+        <Box sx={{
+          order: { xs: 1, sm: 2 },
+          display: 'flex',
+          width: { xs: '100%', sm: 'auto' },
+          justifyContent: 'flex-end',
+          pb: 0.5,
+          pl: { sm: 1 },
+        }}>
+          <ExcelCopyButton result={result} />
+        </Box>
       </Box>
 
       <TabPanel value={tab} index={TAB_TRADES}>


### PR DESCRIPTION
Introduces ExcelPresenter that lazily instantiates the existing domain
presenters inside buildTsv() to format all result sections as TSV, only
when the user actually clicks the button. ExcelCopyButton renders the
button next to the tab strip with idle/ok/error feedback states.

https://claude.ai/code/session_01LixC96nhB5cRVpvbZbfnXS