### PR TITLE
refactor(DataTable): make component presentation-only, closes #15

### DIFF
--- a/src/ui/ResultTabs/DataTable.jsx
+++ b/src/ui/ResultTabs/DataTable.jsx
@@ -136,25 +136,13 @@ function CopyExcelButton({ columns, rows }) {
   )
 }
 
-export default function DataTable({ title, data, countLabel, hint, embedded = false, sx, onCheckChange }) {
+export default function DataTable({ title, columns, rows, countLabel, hint, embedded = false, sx, onToggle }) {
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
-  const { columns, rows } = data
   const dataRows  = rows.filter(r => !r._total)
   const totalRows = rows.filter(r =>  r._total)
   const visible = expanded ? dataRows : dataRows.slice(0, PREVIEW_ROWS)
   const hidden = dataRows.length - PREVIEW_ROWS
-
-  // Internal checkbox state — used only when onCheckChange is not provided
-  const checkCols = columns.filter(c => c.editable === 'checkbox')
-  const [checkState, setCheckState] = useState(() =>
-    Object.fromEntries(checkCols.map(col => [col.key, rows.map(r => r[col.key] ?? true)]))
-  )
-  const handleCheck = (colKey, rowIdx) =>
-    setCheckState(prev => ({
-      ...prev,
-      [colKey]: prev[colKey].map((v, i) => i === rowIdx ? !v : v),
-    }))
 
   return (
     <Box sx={{ mb: embedded ? 0 : 3, ...sx }}>
@@ -212,17 +200,12 @@ export default function DataTable({ title, data, countLabel, hint, embedded = fa
                 {columns.map(col => (
                   <TableCell key={col.key} align={col.align ?? 'left'}>
                     {col.editable === 'checkbox' && !row._total
-                      ? onCheckChange
-                        ? (row[col.key] !== null &&
+                      ? (row[col.key] !== null &&
                           <Checkbox size="small" sx={{ p: 0 }}
                             checked={row[col.key] === true}
                             disabled={row[col.key] === null}
-                            onChange={() => onCheckChange(i)}
+                            onChange={() => onToggle?.(i, col.key)}
                           />)
-                        : <Checkbox size="small" sx={{ p: 0 }}
-                            checked={checkState[col.key]?.[i] ?? true}
-                            onChange={() => handleCheck(col.key, i)}
-                          />
                       : <CellContent col={col} value={row[col.key]} tooltipText={col.tooltip ? row[col.tooltip] : undefined} />
                     }
                   </TableCell>

--- a/src/ui/ResultTabs/DividendsTab.jsx
+++ b/src/ui/ResultTabs/DividendsTab.jsx
@@ -39,7 +39,7 @@ export default function DividendsTab({ result }) {
           </Typography>
         </Box>
       </Box>
-      <DataTable title={t('taxApp8Dividends.tableTitle')} data={data} countLabel={t('taxApp8Dividends.countLabel')} embedded />
+      <DataTable title={t('taxApp8Dividends.tableTitle')} columns={data.columns} rows={data.rows} countLabel={t('taxApp8Dividends.countLabel')} embedded />
     </Box>
   )
 }

--- a/src/ui/ResultTabs/HoldingsTab.jsx
+++ b/src/ui/ResultTabs/HoldingsTab.jsx
@@ -20,7 +20,7 @@ function HoldingsSubTable({ label, data, type, countLabel }) {
   if (rows.length === 0) return null
   const columns = [NUM_COL, ...COLUMNS_WITHOUT_TYPE(data.columns)]
   return (
-    <DataTable title={label} data={{ columns, rows: addRowNumbers(rows) }} countLabel={countLabel} embedded sx={{ mb: 2 }} />
+    <DataTable title={label} columns={columns} rows={addRowNumbers(rows)} countLabel={countLabel} embedded sx={{ mb: 2 }} />
   )
 }
 

--- a/src/ui/ResultTabs/InterestTab.jsx
+++ b/src/ui/ResultTabs/InterestTab.jsx
@@ -68,7 +68,8 @@ export default function InterestTab({ result }) {
 
       <DataTable
         title={t('app.tabs.interest')}
-        data={interestTable}
+        columns={interestTable.columns}
+        rows={interestTable.rows}
         countLabel={t('app.countLabel.payments')}
       />
     </>

--- a/src/ui/ResultTabs/TradesTab.jsx
+++ b/src/ui/ResultTabs/TradesTab.jsx
@@ -41,7 +41,7 @@ export default function TradesTab({ result }) {
 
   const [pending, setPending] = useState(null)
 
-  function handleToggle(idx) {
+  function handleToggle(idx, _colKey) {
     const row = rows[idx]
     if (row.taxable === null) return
 
@@ -81,9 +81,10 @@ export default function TradesTab({ result }) {
     <>
       <DataTable
         title={t('app.tradesTableTitle')}
-        data={trades}
+        columns={trades.columns}
+        rows={trades.rows}
         countLabel={t('app.countLabel.trades')}
-        onCheckChange={handleToggle}
+        onToggle={handleToggle}
         hint={
           <Box sx={{
             display: 'flex', alignItems: 'flex-start', gap: 1,


### PR DESCRIPTION
Remove internal checkbox useState and handleCheck fallback. DataTable
now accepts columns/rows as direct props (instead of a data object) and
delegates all toggle handling to onToggle(rowIndex, colKey). Update all
four call sites (TradesTab, HoldingsTab, DividendsTab, InterestTab)
accordingly.

https://claude.ai/code/session_01CLuBUas7WmoJ9WtTfYv2hx