### PR TITLE
Group holdings with subtitles and exclude them from copy/export (Issue #51)

### DIFF
--- a/src/presentation/ExcelPresenter.js
+++ b/src/presentation/ExcelPresenter.js
@@ -13,7 +13,9 @@ function cellText(col, value) {
 
 function buildSection(name, columns, rows) {
   const header = columns.map(c => c.shortLabel ?? c.label).join('\t')
-  const body = rows.map(row => columns.map(col => cellText(col, row[col.key])).join('\t'))
+  const body = rows
+    .filter(row => !row._total && !row._subtitle)
+    .map(row => columns.map(col => cellText(col, row[col.key])).join('\t'))
   return [name, header, ...body].join('\n')
 }
 

--- a/src/presentation/HoldingPresenter.js
+++ b/src/presentation/HoldingPresenter.js
@@ -5,11 +5,25 @@ export class HoldingPresenter {
   }
 
   buildHoldings(rows) {
+    const sortedRows = this.#mapRows(rows).sort((a, b) =>
+      a.type === b.type ? 0 : a.type === 'Акции' ? -1 : 1
+    )
+    const shares = sortedRows.filter(r => r.type === 'Акции')
+    const funds = sortedRows.filter(r => r.type === 'Дялове')
+    const groupedRows = []
+
+    if (shares.length > 0) {
+      groupedRows.push({ _subtitle: true, label: 'Акции' })
+      groupedRows.push(...shares)
+    }
+    if (funds.length > 0) {
+      groupedRows.push({ _subtitle: true, label: 'Дялове' })
+      groupedRows.push(...funds)
+    }
+
     return {
       columns: this.#columns(),
-      rows: this.#mapRows(rows).sort((a, b) =>
-        a.type === b.type ? 0 : a.type === 'Акции' ? -1 : 1
-      ),
+      rows: groupedRows,
     }
   }
 

--- a/src/ui/ResultTabs/DataTable.jsx
+++ b/src/ui/ResultTabs/DataTable.jsx
@@ -4,6 +4,7 @@ import {
   Box, Button, Checkbox, Chip, Paper, Table, TableBody, TableCell,
   TableContainer, TableHead, TableRow, Tooltip, Typography,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import { Check, ContentCopyOutlined, ExpandLess, ExpandMore, InfoOutlined } from '@mui/icons-material'
 
 const PREVIEW_ROWS = 5
@@ -139,7 +140,8 @@ function CopyExcelButton({ columns, rows }) {
 export default function DataTable({ title, columns, rows, countLabel, hint, embedded = false, sx, onToggle }) {
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
-  const dataRows  = rows.filter(r => !r._total)
+  const copyRows = rows.filter(r => !r._total && !r._subtitle)
+  const dataRows = rows.filter(r => !r._total)
   const totalRows = rows.filter(r =>  r._total)
   const visible = expanded ? dataRows : dataRows.slice(0, PREVIEW_ROWS)
   const hidden = dataRows.length - PREVIEW_ROWS
@@ -157,11 +159,11 @@ export default function DataTable({ title, columns, rows, countLabel, hint, embe
           {title && (
             <>
               <Typography variant="subtitle2" fontWeight={700}>{title}</Typography>
-              <Chip label={dataRows.length} size="small" color="primary" />
+              <Chip label={copyRows.length} size="small" color="primary" />
             </>
           )}
           <Box sx={{ ml: 'auto' }}>
-            <CopyExcelButton columns={columns} rows={dataRows} />
+            <CopyExcelButton columns={columns} rows={copyRows} />
           </Box>
         </Box>
 
@@ -191,25 +193,40 @@ export default function DataTable({ title, columns, rows, countLabel, hint, embe
             {[...visible, ...totalRows].map((row, i) => (
               <TableRow
                 key={i}
-                hover={!row._total}
-                sx={row._total ? {
-                  backgroundColor: 'grey.50',
-                  '& td': { fontWeight: 700, borderTop: '2px solid', borderTopColor: 'divider' },
-                } : undefined}
+                hover={!row._total && !row._subtitle}
+                sx={
+                  row._total ? {
+                    backgroundColor: 'grey.50',
+                    '& td': { fontWeight: 700, borderTop: '2px solid', borderTopColor: 'divider' },
+                  } : row._subtitle ? {
+                    backgroundColor: (theme) =>
+                      alpha(theme.palette.primary.main, theme.palette.mode === 'light' ? 0.08 : 0.16),
+                    '& td': {
+                      fontWeight: 500,
+                      textTransform: 'uppercase',
+                    },
+                  } : undefined
+                }
               >
-                {columns.map(col => (
-                  <TableCell key={col.key} align={col.align ?? 'left'}>
-                    {col.editable === 'checkbox' && !row._total
-                      ? (row[col.key] !== null &&
-                          <Checkbox size="small" sx={{ p: 0 }}
-                            checked={row[col.key] === true}
-                            disabled={row[col.key] === null}
-                            onChange={() => onToggle?.(i, col.key)}
-                          />)
-                      : <CellContent col={col} value={row[col.key]} tooltipText={col.tooltip ? row[col.tooltip] : undefined} />
-                    }
+                {row._subtitle ? (
+                  <TableCell colSpan={columns.length}>
+                    <Typography variant="body2">{row.label}</Typography>
                   </TableCell>
-                ))}
+                ) : (
+                  columns.map(col => (
+                    <TableCell key={col.key} align={col.align ?? 'left'}>
+                      {col.editable === 'checkbox' && !row._total
+                        ? (row[col.key] !== null &&
+                            <Checkbox size="small" sx={{ p: 0 }}
+                              checked={row[col.key] === true}
+                              disabled={row[col.key] === null}
+                              onChange={() => onToggle?.(i, col.key)}
+                            />)
+                        : <CellContent col={col} value={row[col.key]} tooltipText={col.tooltip ? row[col.tooltip] : undefined} />
+                      }
+                    </TableCell>
+                  ))
+                )}
               </TableRow>
             ))}
           </TableBody>

--- a/src/ui/ResultTabs/HoldingsTab.jsx
+++ b/src/ui/ResultTabs/HoldingsTab.jsx
@@ -6,23 +6,12 @@ import DataTable from './DataTable.jsx'
 import { HoldingPresenter } from '../../presentation/HoldingPresenter.js'
 import ThresholdWarning from '../ThresholdWarning.jsx'
 
-const COLUMNS_WITHOUT_TYPE = (columns) =>
-  columns.filter(c => c.key !== 'type')
-
 function addRowNumbers(rows) {
-  return rows.map((r, i) => ({ '#': i + 1, ...r }))
+  let i = 1
+  return rows.map((r) => (r._subtitle ? r : { '#': i++, ...r }))
 }
 
 const NUM_COL = { key: '#', label: '#', align: 'right', mono: true, decimals: 0 }
-
-function HoldingsSubTable({ label, data, type, countLabel }) {
-  const rows = data.rows.filter(r => r.type === type)
-  if (rows.length === 0) return null
-  const columns = [NUM_COL, ...COLUMNS_WITHOUT_TYPE(data.columns)]
-  return (
-    <DataTable title={label} columns={columns} rows={addRowNumbers(rows)} countLabel={countLabel} embedded sx={{ mb: 2 }} />
-  )
-}
 
 export default function TaxApp8Holdings({ result }) {
   const holdingsPresenter = new HoldingPresenter({
@@ -58,8 +47,13 @@ export default function TaxApp8Holdings({ result }) {
           </Typography>
         </Box>
       </Box>
-      <HoldingsSubTable label={t('taxApp8Holdings.shares')} data={data} type="Акции" countLabel={t('taxApp8Holdings.countLabel')} />
-      <HoldingsSubTable label={t('taxApp8Holdings.funds')}  data={data} type="Дялове" countLabel={t('taxApp8Holdings.countLabel')} />
+      <DataTable
+        columns={[NUM_COL, ...data.columns]}
+        rows={addRowNumbers(data.rows)}
+        countLabel={t('taxApp8Holdings.countLabel')}
+        embedded
+        sx={{ mb: 2 }}
+      />
       <ThresholdWarning
         holdings={result.holdings}
         localCurrencyLabel={result.localCurrencyLabel}


### PR DESCRIPTION
### Motivation
- Change the holdings copy/export format so the UI can show grouped sections (shares / funds) while copied/exported TSV remains a flat table without group headers, and the holdings `Вид` column remains present for copy/export compatibility.
- Provide a single combined holdings table in the UI with visible grouping, consistent numbering, and correct behaviour for copy-to-Excel and full TSV export.

### Description
- `src/presentation/HoldingPresenter.js`: buildHoldings now groups rows and inserts `_subtitle` marker rows for `Акции` and `Дялове`, returning a single combined rows array.
- `src/ui/ResultTabs/DataTable.jsx`: added support for `_subtitle` rows (full-width row via `colSpan`, custom background/typography, no hover), adjusted row hover behaviour, and introduced `copyRows` to exclude `_subtitle` rows from the Copy-to-Excel button; the chip count now reflects copyable rows.
- `src/ui/ResultTabs/HoldingsTab.jsx`: replaced two subtables with a single `DataTable` instance, adjusted row numbering to skip subtitle rows so numbering is contiguous for data rows.
- `src/presentation/ExcelPresenter.js`: export logic now filters out `_subtitle` rows (and `_total`) so TSV exports do not include UI group headers.

### Testing
- Ran `npm test` which passed: 12 test files, 154 tests passed.
- Ran `npm run lint` which failed due to pre-existing lint issues in unrelated files (`src/App.jsx`, `src/application/__tests__/calculateTax.js`, `src/ui/ResultTabs/TradesTab.jsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecbc67c3f4832ba997e5fabe87bc92)