### PR TITLE
refactor(parsers): convert numeric fields to Decimal at parse boundary

### DIFF
--- a/src/application/inferPriorPositions.js
+++ b/src/application/inferPriorPositions.js
@@ -1,18 +1,10 @@
-import Decimal from 'decimal.js'
 import {
   toLocalCurrency, getPrevYearEndDate,
 } from '../domain/fx/fxRates.js'
 import { buildInstrumentInfo } from '../domain/parser/parseInstruments.js'
 import { buildCsvTradeBasis } from '../domain/parser/parseCsvTrades.js'
 import { parseTaxYear } from '../domain/parser/parseTaxYear.js'
-
-const D0 = new Decimal(0)
-
-function toD(v) {
-  if (v instanceof Decimal) return v
-  const s = String(v ?? 0).replace(/,/g, '').trim()
-  try { return new Decimal(s) } catch { return D0 }
-}
+import { toDecimal, D0 } from '../domain/numStr.js'
 
 /**
  * Infer prior-year open positions from current-year trade data.
@@ -42,10 +34,10 @@ export function inferPriorPositions({ trades, openPositions, csvTrades, instrume
   for (const t of trades) {
     if (!t.symbol || !t.side) continue
 
-    const qtyD      = toD(t.quantity).abs()
-    const proceedsD = toD(t.proceeds)
-    const commD     = toD(t.commission)
-    const feeD      = toD(t.fee)
+    const qtyD      = toDecimal(t.quantity).abs()
+    const proceedsD = toDecimal(t.proceeds)
+    const commD     = toDecimal(t.commission)
+    const feeD      = toDecimal(t.fee)
     const date      = (t.datetime || '').split(/[,\s]/)[0]
     // For BUY: proceeds is negative (cash out), totalWithFee is negative → neg() = cost paid
     const totalWithFeeD = proceedsD.plus(commD).plus(feeD)
@@ -80,15 +72,15 @@ export function inferPriorPositions({ trades, openPositions, csvTrades, instrume
 
   // Symbols still open at year-end
   for (const h of openPositions) {
-    if (!h.symbol || !parseFloat(h.quantity)) continue
+    if (!h.symbol || !h.quantity?.gt(0)) continue
 
     const aliases = instrumentInfo[h.symbol]?.aliases ?? []
     const sym = bySymbol[h.symbol]
       ?? aliases.map(a => bySymbol[a]).find(Boolean)
       ?? { currency: h.currency, buyQty: D0, buyCostUSD: D0, sellQty: D0, sellBasisUSD: D0, lastBuyDate: null }
 
-    const openQtyD  = toD(h.quantity)
-    const openCostD = toD(h.costBasis)
+    const openQtyD  = toDecimal(h.quantity)
+    const openCostD = toDecimal(h.costBasis)
 
     const priorQtyD = openQtyD.plus(sym.sellQty).minus(sym.buyQty)
     if (priorQtyD.lte(0)) continue  // all shares were bought in current year

--- a/src/controllers/useTaxAppController.js
+++ b/src/controllers/useTaxAppController.js
@@ -6,6 +6,7 @@ import { calculateTax } from '../application/calculateTax.js'
 import { inferPriorPositions } from '../application/inferPriorPositions.js'
 import { getPrevYearEndDate } from '../domain/fx/fxRates.js'
 import { useThemeMode } from '../hooks/useThemeMode.js'
+import { decimalJsonReplacer } from '../domain/numStr.js'
 
 export function useTaxAppController() {
   const [nightMode, setNightMode] = useThemeMode()
@@ -190,7 +191,7 @@ export function useTaxAppController() {
   }
 
   const inputJsonText = inputData ? JSON.stringify(inputData, null, 2) : ''
-  const outputJsonText = result ? JSON.stringify(result, null, 2) : ''
+  const outputJsonText = result ? JSON.stringify(result, decimalJsonReplacer, 2) : ''
 
   return {
     nightMode, setNightMode,

--- a/src/domain/__tests__/numStr.test.js
+++ b/src/domain/__tests__/numStr.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import Decimal from 'decimal.js'
+import { toDecimal, decimalToNumber, D0 } from '../numStr.js'
+
+describe('toDecimal', () => {
+  it('passes Decimal through unchanged', () => {
+    const d = new Decimal('1')
+    expect(toDecimal(d)).toBe(d)
+  })
+
+  it('wraps a string', () => {
+    expect(toDecimal('1.5')).toEqual(new Decimal('1.5'))
+  })
+
+  it('wraps a number', () => {
+    expect(toDecimal(2)).toEqual(new Decimal(2))
+  })
+
+  it('handles null → D0', () => {
+    expect(toDecimal(null)).toEqual(D0)
+  })
+
+  it('handles undefined → D0', () => {
+    expect(toDecimal(undefined)).toEqual(D0)
+  })
+
+  it('handles comma-formatted string', () => {
+    expect(toDecimal('1,500')).toEqual(new Decimal(1500))
+  })
+
+  it('handles invalid string → D0', () => {
+    expect(toDecimal('abc')).toEqual(D0)
+  })
+})
+
+describe('decimalToNumber', () => {
+  it('converts Decimal to number', () => {
+    expect(decimalToNumber(new Decimal('1.5'))).toBe(1.5)
+  })
+
+  it('passes number through unchanged', () => {
+    expect(decimalToNumber(3)).toBe(3)
+  })
+
+  it('returns null for null', () => {
+    expect(decimalToNumber(null)).toBeNull()
+  })
+
+  it('returns null for undefined', () => {
+    expect(decimalToNumber(undefined)).toBeNull()
+  })
+})

--- a/src/domain/__tests__/tradeSummary.test.js
+++ b/src/domain/__tests__/tradeSummary.test.js
@@ -1,33 +1,32 @@
 import { describe, it, expect } from 'vitest'
+import Decimal from 'decimal.js'
 import { buildTradeTotals, buildTaxSummary } from '../tradeSummary.js'
 
 function makeSell(fields = {}) {
   return {
-    side:            'SELL',
-    currency:        fields.currency        ?? 'USD',
-    taxable:         fields.taxable         ?? true,
-    taxExemptLabel:  fields.taxExemptLabel  ?? 'Облагаем',
-    proceeds:        fields.proceeds        ?? 100,
-    commission:      fields.commission      ?? -2,
-    fee:             fields.fee             ?? 0,
-    totalWithFee:    fields.totalWithFee    ?? 98,
-    totalWithFeeLcl: fields.totalWithFeeLcl ?? 191.67,
-    costBasisLcl:    fields.costBasisLcl    ?? 176.03,
+    side:         'SELL',
+    currency:     fields.currency     ?? 'USD',
+    taxable:      fields.taxable      ?? true,
+    proceeds:     new Decimal(fields.proceeds     ?? 100),
+    commission:   new Decimal(fields.commission   ?? -2),
+    fee:          new Decimal(fields.fee          ?? 0),
+    total:        new Decimal(fields.total        ?? 98),
+    totalLcl:     new Decimal(fields.totalLcl     ?? 191.67),
+    costBasisLcl: fields.costBasisLcl != null ? new Decimal(fields.costBasisLcl) : new Decimal(176.03),
   }
 }
 
 function makeBuy(fields = {}) {
   return {
-    side:            'BUY',
-    currency:        fields.currency        ?? 'USD',
-    taxable:         null,
-    taxExemptLabel:  '',
-    proceeds:        fields.proceeds        ?? -100,
-    commission:      fields.commission      ?? -2,
-    fee:             fields.fee             ?? 0,
-    totalWithFee:    fields.totalWithFee    ?? -102,
-    totalWithFeeLcl: fields.totalWithFeeLcl ?? -199.49,
-    costBasisLcl:    fields.costBasisLcl    ?? null,
+    side:         'BUY',
+    currency:     fields.currency  ?? 'USD',
+    taxable:      null,
+    proceeds:     new Decimal(fields.proceeds   ?? -100),
+    commission:   new Decimal(fields.commission ?? -2),
+    fee:          new Decimal(fields.fee        ?? 0),
+    total:        new Decimal(fields.total      ?? -102),
+    totalLcl:     new Decimal(fields.totalLcl   ?? -199.49),
+    costBasisLcl: null,
   }
 }
 
@@ -36,10 +35,10 @@ describe('buildTradeTotals', () => {
     expect(buildTradeTotals([])).toEqual([])
   })
 
-  it('builds total rows grouped by taxExemptLabel and currency', () => {
+  it('builds total rows grouped by taxable and currency', () => {
     const rows = [
-      makeSell({ currency: 'USD', taxExemptLabel: 'Облагаем', totalWithFee: 100, totalWithFeeLcl: 195.58 }),
-      makeSell({ currency: 'EUR', taxExemptLabel: 'Облагаем', totalWithFee: 200, totalWithFeeLcl: 391.17 }),
+      makeSell({ currency: 'USD', taxable: true,  totalLcl: 195.58 }),
+      makeSell({ currency: 'EUR', taxable: true,  totalLcl: 391.17 }),
     ]
     const totals = buildTradeTotals(rows)
     expect(totals.some(r => r.currency === 'USD' && r.taxExemptLabel === 'Облагаем')).toBe(true)
@@ -47,7 +46,7 @@ describe('buildTradeTotals', () => {
   })
 
   it('includes a BGN grand total row per group', () => {
-    const rows = [makeSell({ currency: 'USD', taxExemptLabel: 'Облагаем', totalWithFeeLcl: 195.58 })]
+    const rows = [makeSell({ currency: 'USD', taxable: true, totalLcl: 195.58 })]
     const totals = buildTradeTotals(rows, 'BGN')
     expect(totals.some(r => r.currency === 'BGN')).toBe(true)
   })
@@ -58,33 +57,33 @@ describe('buildTradeTotals', () => {
     expect(totals.every(r => r._total === true)).toBe(true)
   })
 
-  it('sums proceeds, commission, fee and totalWithFee correctly', () => {
+  it('sums proceeds, commission, fee and total correctly', () => {
     const rows = [
-      makeSell({ currency: 'USD', taxExemptLabel: 'Облагаем', proceeds: 100, commission: -2, fee: -1, totalWithFee: 97 }),
-      makeSell({ currency: 'USD', taxExemptLabel: 'Облагаем', proceeds: 200, commission: -3, fee: -2, totalWithFee: 195 }),
+      makeSell({ currency: 'USD', taxable: true, proceeds: 100, commission: -2, fee: -1, total: 97 }),
+      makeSell({ currency: 'USD', taxable: true, proceeds: 200, commission: -3, fee: -2, total: 195 }),
     ]
     const totals = buildTradeTotals(rows)
     const usdTotal = totals.find(r => r.currency === 'USD' && r.taxExemptLabel === 'Облагаем')
-    expect(usdTotal.proceeds).toBeCloseTo(300)
-    expect(usdTotal.commission).toBeCloseTo(-5)
-    expect(usdTotal.totalWithFee).toBeCloseTo(292)
+    expect(usdTotal.proceeds.toNumber()).toBeCloseTo(300)
+    expect(usdTotal.commission.toNumber()).toBeCloseTo(-5)
+    expect(usdTotal.total.toNumber()).toBeCloseTo(292)
   })
 
-  it('handles Освободен (exempt) group separately', () => {
+  it('handles exempt group separately', () => {
     const rows = [
-      makeSell({ taxExemptLabel: 'Облагаем', totalWithFeeLcl: 100 }),
-      makeSell({ taxExemptLabel: 'Освободен', totalWithFeeLcl: 200 }),
+      makeSell({ taxable: true,  totalLcl: 100 }),
+      makeSell({ taxable: false, totalLcl: 200 }),
     ]
     const totals = buildTradeTotals(rows)
     const taxableTotal = totals.find(r => r.taxExemptLabel === 'Облагаем')
     const exemptTotal  = totals.find(r => r.taxExemptLabel === 'Освободен')
-    expect(taxableTotal?.totalWithFeeLcl).toBeCloseTo(100)
-    expect(exemptTotal?.totalWithFeeLcl).toBeCloseTo(200)
+    expect(taxableTotal?.totalLcl.toNumber()).toBeCloseTo(100)
+    expect(exemptTotal?.totalLcl.toNumber()).toBeCloseTo(200)
   })
 
   it('skips currency groups with no trades', () => {
     // Only USD trades — no EUR totals row should appear
-    const rows = [makeSell({ currency: 'USD', taxExemptLabel: 'Облагаем' })]
+    const rows = [makeSell({ currency: 'USD', taxable: true })]
     const totals = buildTradeTotals(rows)
     expect(totals.some(r => r.currency === 'EUR')).toBe(false)
   })
@@ -97,66 +96,67 @@ describe('buildTaxSummary', () => {
     expect(result).toHaveProperty('sumExempt')
   })
 
-  it('returns zeros for empty input', () => {
+  it('returns Decimal zeros for empty input', () => {
     const { sumTaxable, sumExempt } = buildTaxSummary([])
-    expect(sumTaxable.profits).toBe(0)
-    expect(sumTaxable.losses).toBe(0)
-    expect(sumExempt.profits).toBe(0)
+    expect(sumTaxable.profits).toBeInstanceOf(Decimal)
+    expect(sumTaxable.profits.toNumber()).toBe(0)
+    expect(sumTaxable.losses.toNumber()).toBe(0)
+    expect(sumExempt.profits.toNumber()).toBe(0)
   })
 
   it('calculates taxable sell profits in sumTaxable', () => {
     const rows = [
-      makeSell({ taxable: true, totalWithFeeLcl: 200, costBasisLcl: 150 }),
+      makeSell({ taxable: true, totalLcl: 200, costBasisLcl: 150 }),
     ]
     const { sumTaxable } = buildTaxSummary(rows)
-    expect(sumTaxable.profits).toBeCloseTo(50)
-    expect(sumTaxable.losses).toBe(0)
+    expect(sumTaxable.profits.toNumber()).toBeCloseTo(50)
+    expect(sumTaxable.losses.toNumber()).toBe(0)
   })
 
   it('calculates taxable sell losses in sumTaxable', () => {
     const rows = [
-      makeSell({ taxable: true, totalWithFeeLcl: 100, costBasisLcl: 150 }),
+      makeSell({ taxable: true, totalLcl: 100, costBasisLcl: 150 }),
     ]
     const { sumTaxable } = buildTaxSummary(rows)
-    expect(sumTaxable.profits).toBe(0)
-    expect(sumTaxable.losses).toBeCloseTo(50)
+    expect(sumTaxable.profits.toNumber()).toBe(0)
+    expect(sumTaxable.losses.toNumber()).toBeCloseTo(50)
   })
 
   it('puts exempt sells into sumExempt, not sumTaxable', () => {
     const rows = [
-      makeSell({ taxable: false, totalWithFeeLcl: 200, costBasisLcl: 150 }),
+      makeSell({ taxable: false, totalLcl: 200, costBasisLcl: 150 }),
     ]
     const { sumTaxable, sumExempt } = buildTaxSummary(rows)
-    expect(sumTaxable.profits).toBe(0)
-    expect(sumExempt.profits).toBeCloseTo(50)
+    expect(sumTaxable.profits.toNumber()).toBe(0)
+    expect(sumExempt.profits.toNumber()).toBeCloseTo(50)
   })
 
   it('ignores BUY rows when calculating summaries', () => {
     const rows = [
-      makeBuy({ totalWithFeeLcl: -500, costBasisLcl: null }),
+      makeBuy({ totalLcl: -500 }),
     ]
     const { sumTaxable, sumExempt } = buildTaxSummary(rows)
-    expect(sumTaxable.profits).toBe(0)
-    expect(sumExempt.profits).toBe(0)
+    expect(sumTaxable.profits.toNumber()).toBe(0)
+    expect(sumExempt.profits.toNumber()).toBe(0)
   })
 
   it('handles mixed profits and losses in the same group', () => {
     const rows = [
-      makeSell({ taxable: true, totalWithFeeLcl: 200, costBasisLcl: 150 }),
-      makeSell({ taxable: true, totalWithFeeLcl: 80,  costBasisLcl: 100 }),
+      makeSell({ taxable: true, totalLcl: 200, costBasisLcl: 150 }),
+      makeSell({ taxable: true, totalLcl: 80,  costBasisLcl: 100 }),
     ]
     const { sumTaxable } = buildTaxSummary(rows)
-    expect(sumTaxable.profits).toBeCloseTo(50)
-    expect(sumTaxable.losses).toBeCloseTo(20)
+    expect(sumTaxable.profits.toNumber()).toBeCloseTo(50)
+    expect(sumTaxable.losses.toNumber()).toBeCloseTo(20)
   })
 
-  it('calculates totalProceedsLcl and totalcostBasisLcl', () => {
+  it('calculates totalProceedsLcl and totalCostBasisLcl', () => {
     const rows = [
-      makeSell({ taxable: true, totalWithFeeLcl: 200, costBasisLcl: 150 }),
-      makeSell({ taxable: true, totalWithFeeLcl: 300, costBasisLcl: 200 }),
+      makeSell({ taxable: true, totalLcl: 200, costBasisLcl: 150 }),
+      makeSell({ taxable: true, totalLcl: 300, costBasisLcl: 200 }),
     ]
     const { sumTaxable } = buildTaxSummary(rows)
-    expect(sumTaxable.totalProceedsLcl).toBeCloseTo(500)
-    expect(sumTaxable.totalCostBasisLcl).toBeCloseTo(350)
+    expect(sumTaxable.totalProceedsLcl.toNumber()).toBeCloseTo(500)
+    expect(sumTaxable.totalCostBasisLcl.toNumber()).toBeCloseTo(350)
   })
 })

--- a/src/domain/numStr.js
+++ b/src/domain/numStr.js
@@ -37,3 +37,31 @@ export function toDisplayStr(value) {
   if (!s.includes('.')) return s
   return s.replace(/(\.\d*?)0+$/, '$1').replace(/\.$/, '')
 }
+
+/**
+ * Robust Decimal coercion — handles Decimal, number, or string input.
+ * Replaces the various local toD() helpers scattered across calculators.
+ */
+export function toDecimal(v) {
+  if (v instanceof Decimal) return v
+  const s = String(v ?? 0).replace(/,/g, '').trim()
+  try { return new Decimal(s) } catch { return D0 }
+}
+
+/**
+ * Explicit Decimal → number conversion.
+ * Only for dev JSON and TSV export paths.
+ */
+export function decimalToNumber(v) {
+  if (v == null) return null
+  if (v instanceof Decimal) return v.toNumber()
+  if (typeof v === 'number') return v
+  return null
+}
+
+/**
+ * JSON.stringify replacer that converts Decimal instances to JS numbers.
+ * Use for outputJsonText in the dev panel.
+ */
+export const decimalJsonReplacer = (key, value) =>
+  value instanceof Decimal ? value.toNumber() : value

--- a/src/domain/parser/__tests__/parseCsvTrades.test.js
+++ b/src/domain/parser/__tests__/parseCsvTrades.test.js
@@ -41,19 +41,17 @@ describe('parseCsvTrades', () => {
     const rows = [makeHeader(), makeTrade()]
     const result = parseCsvTrades(rows)
     expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({
-      assetCategory: 'Stocks',
-      currency:      'USD',
-      symbol:        'AAPL',
-      exchange:      'NASDAQ',
-      side:          'BUY',
-      quantity:      '10',
-      price:         '150.00',
-      proceeds:      '-1500.00',
-      commission:    '-5.00',
-      basis:         '-1505.00',
-      code:          'O',
-    })
+    expect(result[0].assetCategory).toBe('Stocks')
+    expect(result[0].currency).toBe('USD')
+    expect(result[0].symbol).toBe('AAPL')
+    expect(result[0].exchange).toBe('NASDAQ')
+    expect(result[0].side).toBe('BUY')
+    expect(result[0].quantity).toEqual(new Decimal('10'))
+    expect(result[0].price).toEqual(new Decimal('150.00'))
+    expect(result[0].proceeds).toEqual(new Decimal('-1500.00'))
+    expect(result[0].commission).toEqual(new Decimal('-5.00'))
+    expect(result[0].basis).toEqual(new Decimal('-1505.00'))
+    expect(result[0].code).toBe('O')
   })
 
   it('strips quotes from datetime field', () => {
@@ -87,8 +85,8 @@ describe('parseCsvTrades', () => {
     ]
     const result = parseCsvTrades(rows)
     expect(result[0].side).toBe('SELL')
-    expect(result[0].quantity).toBe('-10')
-    expect(result[0].proceeds).toBe('1800.00')
+    expect(result[0].quantity).toEqual(new Decimal('-10'))
+    expect(result[0].proceeds).toEqual(new Decimal('1800.00'))
   })
 })
 

--- a/src/domain/parser/__tests__/parseDividends.test.js
+++ b/src/domain/parser/__tests__/parseDividends.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import Decimal from 'decimal.js'
 import { parseDividends, parseWithholdingTax } from '../parseDividends.js'
 
 // Helper: build rows with a Dividends header + optional data rows
@@ -24,12 +25,10 @@ describe('parseDividends', () => {
     ])
     const result = parseDividends(rows)
     expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({
-      currency: 'USD',
-      date: '2025-03-15',
-      description: 'AAPL(US0378331005) Cash Dividend',
-      amount: '10.00',
-    })
+    expect(result[0].currency).toBe('USD')
+    expect(result[0].date).toBe('2025-03-15')
+    expect(result[0].description).toBe('AAPL(US0378331005) Cash Dividend')
+    expect(result[0].amount).toEqual(new Decimal('10.00'))
   })
 
   it('parses multiple dividend rows', () => {
@@ -110,13 +109,11 @@ describe('parseWithholdingTax', () => {
     ])
     const result = parseWithholdingTax(rows)
     expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({
-      currency: 'USD',
-      date: '2025-03-15',
-      description: 'AAPL(US0378331005) Cash Dividend',
-      amount: '-1.50',
-      code: 'Po',
-    })
+    expect(result[0].currency).toBe('USD')
+    expect(result[0].date).toBe('2025-03-15')
+    expect(result[0].description).toBe('AAPL(US0378331005) Cash Dividend')
+    expect(result[0].amount).toEqual(new Decimal('-1.50'))
+    expect(result[0].code).toBe('Po')
   })
 
   it('skips rows where Currency starts with "Total"', () => {
@@ -133,7 +130,7 @@ describe('parseWithholdingTax', () => {
     ])
     const result = parseWithholdingTax(rows)
     expect(result).toHaveLength(1)
-    expect(result[0].amount).toBe('-1.50')
+    expect(result[0].amount).toEqual(new Decimal('-1.50'))
   })
 
   it('handles empty input gracefully', () => {

--- a/src/domain/parser/__tests__/parseInterest.test.js
+++ b/src/domain/parser/__tests__/parseInterest.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import Decimal from 'decimal.js'
 import { parseInterest } from '../parseInterest.js'
 
 function makeRows(dataRows = []) {
@@ -18,12 +19,10 @@ describe('parseInterest', () => {
     ])
     const result = parseInterest(rows)
     expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({
-      currency: 'USD',
-      date: '2025-02-28',
-      description: 'USD Credit Interest for Feb-2025',
-      amount: '12.34',
-    })
+    expect(result[0].currency).toBe('USD')
+    expect(result[0].date).toBe('2025-02-28')
+    expect(result[0].description).toBe('USD Credit Interest for Feb-2025')
+    expect(result[0].amount).toEqual(new Decimal('12.34'))
   })
 
   it('parses multiple interest rows', () => {

--- a/src/domain/parser/__tests__/parseOpenPositions.test.js
+++ b/src/domain/parser/__tests__/parseOpenPositions.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import Decimal from 'decimal.js'
 import { parseOpenPositions, buildOpenPositions } from '../parseOpenPositions.js'
 
 // Real IBKR CSV: index 2 of the header row is 'DataDiscriminator';
@@ -39,17 +40,15 @@ describe('parseOpenPositions', () => {
     const rows = [makeHeader(), makePositionRow()]
     const result = parseOpenPositions(rows)
     expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({
-      assetCategory: 'Stocks',
-      currency:      'USD',
-      symbol:        'AAPL',
-      quantity:      '100',
-      costPrice:     '150.00',
-      costBasis:     '15000.00',
-      closePrice:    '180.00',
-      value:         '18000.00',
-      unrealizedPL:  '3000.00',
-    })
+    expect(result[0].assetCategory).toBe('Stocks')
+    expect(result[0].currency).toBe('USD')
+    expect(result[0].symbol).toBe('AAPL')
+    expect(result[0].quantity).toEqual(new Decimal('100'))
+    expect(result[0].costPrice).toEqual(new Decimal('150.00'))
+    expect(result[0].costBasis).toEqual(new Decimal('15000.00'))
+    expect(result[0].closePrice).toEqual(new Decimal('180.00'))
+    expect(result[0].value).toEqual(new Decimal('18000.00'))
+    expect(result[0].unrealizedPL).toEqual(new Decimal('3000.00'))
   })
 
   it('only includes Summary rows, not Total rows', () => {
@@ -81,24 +80,24 @@ describe('buildOpenPositions', () => {
     expect(Array.isArray(result.rows)).toBe(true)
   })
 
-  it('converts quantity and costBasis to numbers', () => {
+  it('returns Decimal for quantity and costBasis', () => {
     const rawPositions = parseOpenPositions([makeHeader(), makePositionRow()])
     const { rows } = buildOpenPositions(rawPositions)
-    expect(typeof rows[0].quantity).toBe('number')
-    expect(typeof rows[0].costBasis).toBe('number')
+    expect(rows[0].quantity).toBeInstanceOf(Decimal)
+    expect(rows[0].costBasis).toBeInstanceOf(Decimal)
   })
 
   it('uses calculated costBasis from positionsCostBasis when available', () => {
     const rawPositions = parseOpenPositions([makeHeader(), makePositionRow({ symbol: 'AAPL', costBasis: '15000.00' })])
-    const positionsCostBasis = { AAPL: { cost: 12000, qty: 100 } }
+    const positionsCostBasis = { AAPL: { cost: new Decimal(12000), qty: new Decimal(100) } }
     const { rows } = buildOpenPositions(rawPositions, {}, positionsCostBasis)
-    expect(rows[0].costBasis).toBe(12000)
+    expect(rows[0].costBasis).toEqual(new Decimal(12000))
   })
 
   it('falls back to raw costBasis when positionsCostBasis has no entry', () => {
     const rawPositions = parseOpenPositions([makeHeader(), makePositionRow({ costBasis: '15000.00' })])
     const { rows } = buildOpenPositions(rawPositions, {}, {})
-    expect(rows[0].costBasis).toBeCloseTo(15000)
+    expect(rows[0].costBasis.toNumber()).toBeCloseTo(15000)
   })
 
   it('enriches rows with country from instrumentInfo', () => {
@@ -117,8 +116,8 @@ describe('buildOpenPositions', () => {
   it('handles comma-formatted numbers', () => {
     const rawPositions = parseOpenPositions([makeHeader(), makePositionRow({ costBasis: '1,500,000.00', quantity: '1,000' })])
     const { rows } = buildOpenPositions(rawPositions)
-    expect(rows[0].costBasis).toBeCloseTo(1500000)
-    expect(rows[0].quantity).toBeCloseTo(1000)
+    expect(rows[0].costBasis.toNumber()).toBeCloseTo(1500000)
+    expect(rows[0].quantity.toNumber()).toBeCloseTo(1000)
   })
 })
 

--- a/src/domain/parser/__tests__/parseTradesHtml.test.js
+++ b/src/domain/parser/__tests__/parseTradesHtml.test.js
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from 'vitest'
+import Decimal from 'decimal.js'
 import { parseTradesFromHtml } from '../parseTradesHtml.js'
 
 function parseHtml(html) {
@@ -83,22 +84,20 @@ describe('parseTradesFromHtml', () => {
     const html = buildHtml(stocksSection('USD', trade({})))
     const result = parseTradesFromHtml(parseHtml(html))
     expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({
-      asset:      'Stocks',
-      currency:   'USD',
-      symbol:     'AAPL',
-      datetime:   '2025-10-08, 14:30:00',
-      settleDate: '2025-10-10',
-      exchange:   'NASDAQ',
-      side:       'BUY',
-      quantity:   '10',
-      price:      '174.5000',
-      proceeds:   '-1,745.00',
-      commission: '-2.50',
-      fee:        '0.00',
-      orderType:  'LMT',
-      code:       'O',
-    })
+    expect(result[0].asset).toBe('Stocks')
+    expect(result[0].currency).toBe('USD')
+    expect(result[0].symbol).toBe('AAPL')
+    expect(result[0].datetime).toBe('2025-10-08, 14:30:00')
+    expect(result[0].settleDate).toBe('2025-10-10')
+    expect(result[0].exchange).toBe('NASDAQ')
+    expect(result[0].side).toBe('BUY')
+    expect(result[0].quantity).toEqual(new Decimal('10'))
+    expect(result[0].price).toEqual(new Decimal('174.5'))
+    expect(result[0].proceeds).toEqual(new Decimal('-1745'))
+    expect(result[0].commission).toEqual(new Decimal('-2.5'))
+    expect(result[0].fee).toEqual(new Decimal('0'))
+    expect(result[0].orderType).toBe('LMT')
+    expect(result[0].code).toBe('O')
   })
 
   it('parses a SELL trade correctly', () => {
@@ -109,8 +108,8 @@ describe('parseTradesFromHtml', () => {
     const result = parseTradesFromHtml(parseHtml(html))
     expect(result).toHaveLength(1)
     expect(result[0].side).toBe('SELL')
-    expect(result[0].quantity).toBe('-5')
-    expect(result[0].proceeds).toBe('900.00')
+    expect(result[0].quantity).toEqual(new Decimal('-5'))
+    expect(result[0].proceeds).toEqual(new Decimal('900'))
     expect(result[0].code).toBe('C')
   })
 

--- a/src/domain/parser/parseCsvTrades.js
+++ b/src/domain/parser/parseCsvTrades.js
@@ -1,5 +1,4 @@
-import Decimal from 'decimal.js'
-import { parseToDecimal } from '../numStr.js'
+import { parseToDecimal, toDecimal } from '../numStr.js'
 
 /**
  * Parses the "Trades" section of an IBKR Activity Statement CSV into a raw array.
@@ -32,12 +31,13 @@ export function parseCsvTrades(rows) {
       settleDate:    (r[colIndex['Settle Date/Time']]  || '').trim(),
       exchange:      (r[colIndex['Exchange']]          || '').trim(),
       side:          (r[colIndex['Buy/Sell']]          || '').trim(),
-      quantity:      (r[colIndex['Quantity']]          || '').trim(),
-      price:         (r[colIndex['Price']]             || '').trim(),
-      proceeds:      (r[colIndex['Proceeds']]          || '').trim(),
-      commission:    (r[colIndex['Comm/Fee']]          || '').trim(),
-      basis:         (r[colIndex['Basis']]             || '').trim(),
-      realizedPL:    (r[colIndex['Realized P/L']]      || '').trim(),
+      quantity:      parseToDecimal((r[colIndex['Quantity']]       || '').trim()),
+      price:         parseToDecimal((r[colIndex['Price']]          || '').trim()),
+      proceeds:      parseToDecimal((r[colIndex['Proceeds']]       || '').trim()),
+      commission:    parseToDecimal((r[colIndex['Comm/Fee']]       || '').trim()),
+      fee:           parseToDecimal((r[colIndex['Fee']]            || '').trim()),
+      basis:         parseToDecimal((r[colIndex['Basis']]          || '').trim()),
+      realizedPL:    parseToDecimal((r[colIndex['Realized P/L']]   || '').trim()),
       code:          (r[colIndex['Code']]              || '').trim(),
     }))
 }
@@ -53,11 +53,11 @@ export function parseCsvTrades(rows) {
 export function buildCsvTradeBasis(csvTrades) {
   const result = new Map()
   for (const t of csvTrades) {
-    const qtyD = parseToDecimal(t.quantity)
+    const qtyD = toDecimal(t.quantity)
     if (!qtyD || qtyD.gte(0)) continue  // only SELL trades have negative quantity
 
     const date   = t.datetime.split(',')[0].trim()
-    const basisD = parseToDecimal(t.basis)
+    const basisD = toDecimal(t.basis)
     if (!t.symbol || !date || !basisD) continue
 
     const key = `${t.symbol}|${date}|${qtyD.abs().toFixed(0)}`

--- a/src/domain/parser/parseDividends.js
+++ b/src/domain/parser/parseDividends.js
@@ -1,5 +1,8 @@
+import { parseToDecimal } from '../numStr.js'
+
 /**
  * Parses the Dividends section into a raw array.
+ * The `amount` field is returned as a Decimal instance.
  *
  * @param {string[][]} rows
  * @returns {object[]}
@@ -23,13 +26,14 @@ export function parseDividends(rows) {
       currency:    (r[idx['Currency']]    || '').trim(),
       date:        (r[idx['Date']]         || '').trim(),
       description: (r[idx['Description']] || '').trim(),
-      amount:      (r[idx['Amount']]       || '').trim(),
+      amount:      parseToDecimal((r[idx['Amount']] || '').trim()),
     }))
-    .filter(r => parseFloat(r.amount) > 0)
+    .filter(r => r.amount?.gt(0))
 }
 
 /**
  * Parses the Withholding Tax section into a raw array.
+ * The `amount` field is returned as a Decimal instance.
  *
  * @param {string[][]} rows
  * @returns {object[]}
@@ -51,7 +55,7 @@ export function parseWithholdingTax(rows) {
       currency:    (r[idx['Currency']]    || '').trim(),
       date:        (r[idx['Date']]         || '').trim(),
       description: (r[idx['Description']] || '').trim(),
-      amount:      (r[idx['Amount']]       || '').trim(),
+      amount:      parseToDecimal((r[idx['Amount']] || '').trim()),
       code:        (r[idx['Code']]         || '').trim(),
     }))
 }

--- a/src/domain/parser/parseInterest.js
+++ b/src/domain/parser/parseInterest.js
@@ -1,5 +1,8 @@
+import { parseToDecimal } from '../numStr.js'
+
 /**
  * Parses the "Interest" section (actual monthly cash payments) into a raw array.
+ * The `amount` field is returned as a Decimal instance.
  *
  * @param {string[][]} rows
  * @returns {object[]}
@@ -23,7 +26,7 @@ export function parseInterest(rows) {
       currency:    (r[idx['Currency']]    || '').trim(),
       date:        (r[idx['Date']]         || '').trim(),
       description: (r[idx['Description']] || '').trim(),
-      amount:      (r[idx['Amount']]       || '').trim(),
+      amount:      parseToDecimal((r[idx['Amount']] || '').trim()),
     }))
-    .filter(r => parseFloat(r.amount) > 0)
+    .filter(r => r.amount?.gt(0))
 }

--- a/src/domain/parser/parseOpenPositions.js
+++ b/src/domain/parser/parseOpenPositions.js
@@ -1,5 +1,6 @@
 import { getInstrumentTypeLabel } from '../instrument/classifier.js'
 import { t } from '../../localization/i18n.js'
+import { parseToDecimal } from '../numStr.js'
 
 /**
  * Parses IBKR "Open Positions" section into a raw array.
@@ -20,13 +21,13 @@ export function parseOpenPositions(rows) {
       assetCategory: (r[colIndex['Asset Category']] || '').trim(),
       currency:      (r[colIndex['Currency']]       || '').trim(),
       symbol:        (r[colIndex['Symbol']]         || '').trim(),
-      quantity:      (r[colIndex['Quantity']]        || '').trim(),
-      multiplier:    (r[colIndex['Mult']]            || '').trim(),
-      costPrice:     (r[colIndex['Cost Price']]      || '').trim(),
-      costBasis:     (r[colIndex['Cost Basis']]      || '').trim(),
-      closePrice:    (r[colIndex['Close Price']]     || '').trim(),
-      value:         (r[colIndex['Value']]           || '').trim(),
-      unrealizedPL:  (r[colIndex['Unrealized P/L']] || '').trim(),
+      quantity:      parseToDecimal((r[colIndex['Quantity']]        || '').trim()),
+      multiplier:    parseToDecimal((r[colIndex['Mult']]            || '').trim()),
+      costPrice:     parseToDecimal((r[colIndex['Cost Price']]      || '').trim()),
+      costBasis:     parseToDecimal((r[colIndex['Cost Basis']]      || '').trim()),
+      closePrice:    parseToDecimal((r[colIndex['Close Price']]     || '').trim()),
+      value:         parseToDecimal((r[colIndex['Value']]           || '').trim()),
+      unrealizedPL:  parseToDecimal((r[colIndex['Unrealized P/L']] || '').trim()),
       code:          (r[colIndex['Code']]            || '').trim(),
     }))
 }
@@ -37,22 +38,19 @@ export function parseOpenPositions(rows) {
  *
  * @param {object[]} rawPositions
  * @param {{ [symbol: string]: object }} instrumentInfo
- * @param {{ [symbol: string]: { cost: number, qty: number } }} positionsCostBasis
+ * @param {{ [symbol: string]: { cost: Decimal, qty: Decimal } }} positionsCostBasis
  * @returns {{ columns: object[], rows: object[] }}
  */
 export function buildOpenPositions(rawPositions, instrumentInfo = {}, positionsCostBasis = {}) {
-  const parseNum = v => {
-    const n = parseFloat((v || '').replace(/,/g, ''))
-    return Number.isFinite(n) ? n : null
-  }
-
   const dataRows = rawPositions.map(r => {
     const symbol   = r.symbol
     const info     = instrumentInfo[symbol] || {}
-    const quantity = parseNum(r.quantity)
+    const quantity = r.quantity
     const calcPos  = positionsCostBasis[symbol]
-    const costBasis = calcPos?.cost != null ? calcPos.cost : parseNum(r.costBasis)
-    const costPrice = quantity ? costBasis / quantity : parseNum(r.costPrice)
+    const costBasis = calcPos?.cost ?? r.costBasis
+    const costPrice = quantity && !quantity.isZero()
+      ? costBasis?.div(quantity)
+      : r.costPrice
     const instrType = getInstrumentTypeLabel({ name: info.description ?? '', type: info.type ?? '' })
     return {
       assetCategory: r.assetCategory,
@@ -61,12 +59,12 @@ export function buildOpenPositions(rawPositions, instrumentInfo = {}, positionsC
       instrType,
       country:      info.countryName || info.country || '',
       quantity,
-      multiplier:   parseNum(r.multiplier),
+      multiplier:   r.multiplier,
       costPrice,
       costBasis,
-      closePrice:   parseNum(r.closePrice),
-      value:        parseNum(r.value),
-      unrealizedPL: parseNum(r.unrealizedPL),
+      closePrice:   r.closePrice,
+      value:        r.value,
+      unrealizedPL: r.unrealizedPL,
       code:         r.code,
     }
   })

--- a/src/domain/parser/parseOpenPositions.js
+++ b/src/domain/parser/parseOpenPositions.js
@@ -1,6 +1,6 @@
 import { getInstrumentTypeLabel } from '../instrument/classifier.js'
 import { t } from '../../localization/i18n.js'
-import { parseToDecimal } from '../numStr.js'
+import { parseToDecimal, toDecimal } from '../numStr.js'
 
 /**
  * Parses IBKR "Open Positions" section into a raw array.
@@ -47,7 +47,7 @@ export function buildOpenPositions(rawPositions, instrumentInfo = {}, positionsC
     const info     = instrumentInfo[symbol] || {}
     const quantity = r.quantity
     const calcPos  = positionsCostBasis[symbol]
-    const costBasis = calcPos?.cost ?? r.costBasis
+    const costBasis = calcPos?.cost != null ? toDecimal(calcPos.cost) : r.costBasis
     const costPrice = quantity && !quantity.isZero()
       ? costBasis?.div(quantity)
       : r.costPrice

--- a/src/domain/parser/parseTradesHtml.js
+++ b/src/domain/parser/parseTradesHtml.js
@@ -1,3 +1,5 @@
+import { parseToDecimal } from '../numStr.js'
+
 /**
  * Parses an IBKR Trade Confirmation Report HTML document into a raw array.
  *
@@ -9,7 +11,7 @@
  *   4: Exchange | 5: Type (side) | 6: Quantity | 7: Price | 8: Proceeds |
  *   9: Comm (commission) | 10: Fee | 11: Order Type | 12: Code
  *
- * All values are raw strings. quantity keeps sign (negative for SELL).
+ * Numeric fields are returned as Decimal instances (null for blank/non-numeric).
  *
  * @param {Document} doc - pre-parsed HTML document
  * @returns {object[]}
@@ -55,11 +57,11 @@ export function parseTradesFromHtml(doc) {
         settleDate: txt(cells[3]),
         exchange,
         side:       txt(cells[5]),
-        quantity:   txt(cells[6]),
-        price:      txt(cells[7]),
-        proceeds:   txt(cells[8]),
-        commission: txt(cells[9]),
-        fee:        txt(cells[10]),
+        quantity:   parseToDecimal(txt(cells[6])),
+        price:      parseToDecimal(txt(cells[7])),
+        proceeds:   parseToDecimal(txt(cells[8])),
+        commission: parseToDecimal(txt(cells[9])),
+        fee:        parseToDecimal(txt(cells[10])),
         orderType:  txt(cells[11]),
         code:       txt(cells[12]),
       })

--- a/src/domain/tax/DividendCalculator.js
+++ b/src/domain/tax/DividendCalculator.js
@@ -1,16 +1,8 @@
 import Decimal from 'decimal.js'
-import {
-  toLocalCurrency
-} from '../fx/fxRates.js'
-
+import { toLocalCurrency } from '../fx/fxRates.js'
+import { toDecimal, D0 } from '../numStr.js'
 
 const BG_DIVIDEND_TAX_RATE = new Decimal('0.05')
-
-function toD(v) {
-  if (v instanceof Decimal) return v
-  const s = String(v ?? 0).replace(/,/g, '').trim()
-  try { return new Decimal(s) } catch { return new Decimal(0) }
-}
 
 export class DividendCalculator {
   constructor({ instrumentInfo, context }) {
@@ -37,11 +29,8 @@ export class DividendCalculator {
       // safer + stable key
       const key = `${d.symbol}|${d.taxCode}`
 
-      const grossD = toLocalCurrency(toD(d.grossAmount), d.currency, d.date, this.ctx.taxYear)
-      const withheldD = toLocalCurrency(toD(d.withheldTax), d.currency, d.date, this.ctx.taxYear)
-
-      const grossLcl = grossD ? grossD.toNumber() : 0
-      const withheldLcl = withheldD ? withheldD.toNumber() : 0
+      const grossD = toLocalCurrency(d.grossAmount, d.currency, d.date, this.ctx.taxYear)
+      const withheldD = toLocalCurrency(d.withheldTax, d.currency, d.date, this.ctx.taxYear)
 
       if (!acc[key]) {
         acc[key] = {
@@ -50,13 +39,13 @@ export class DividendCalculator {
           countryName: d.countryName,
           incomeCategoryCode: 8141,
           methodCode: d.taxCode,
-          grossAmountLcl: 0,
-          foreignTaxPaidLcl: 0,
+          grossAmountLcl: D0,
+          foreignTaxPaidLcl: D0,
         }
       }
 
-      acc[key].grossAmountLcl += grossLcl
-      acc[key].foreignTaxPaidLcl += withheldLcl
+      acc[key].grossAmountLcl = acc[key].grossAmountLcl.plus(grossD ?? D0)
+      acc[key].foreignTaxPaidLcl = acc[key].foreignTaxPaidLcl.plus(withheldD ?? D0)
 
       return acc
     }, {})
@@ -66,13 +55,13 @@ export class DividendCalculator {
     return Object.values(grouped).map(d => {
       const bgTaxLcl =
         d.grossAmountLcl != null
-          ? new Decimal(d.grossAmountLcl).times(BG_DIVIDEND_TAX_RATE).toNumber()
+          ? d.grossAmountLcl.times(BG_DIVIDEND_TAX_RATE)
           : null
 
       const partialCredit =
         bgTaxLcl != null &&
         d.foreignTaxPaidLcl != null &&
-        d.foreignTaxPaidLcl < bgTaxLcl
+        d.foreignTaxPaidLcl.lt(bgTaxLcl)
           ? d.foreignTaxPaidLcl
           : null
 
@@ -80,7 +69,7 @@ export class DividendCalculator {
 
       const dueTaxLcl =
         bgTaxLcl != null && d.foreignTaxPaidLcl != null
-          ? Math.max(0, bgTaxLcl - d.foreignTaxPaidLcl)
+          ? Decimal.max(D0, bgTaxLcl.minus(d.foreignTaxPaidLcl))
           : bgTaxLcl
 
       return {
@@ -99,15 +88,15 @@ export class DividendCalculator {
         const symbol = m ? m[1].trim() : null
         if (!symbol || !wt.date) continue
         const key = `${symbol}_${wt.date}`
-        withholding[key] = (withholding[key] || 0) + parseFloat(wt.amount || '0')
+        withholding[key] = (withholding[key] ?? D0).plus(toDecimal(wt.amount))
     }
 
     return rawDividends.map(d => {
         const m = d.description.match(/^([^(]+)\(/)
         const symbol = m ? m[1].trim() : d.description.split(' ')[0]
         const key = `${symbol}_${d.date}`
-        const grossAmount = parseFloat(d.amount || '0')
-        const withheldTax = Math.abs(withholding[key] || 0)
+        const grossAmount = toDecimal(d.amount)
+        const withheldTax = (withholding[key] ?? D0).abs()
         const info = instrumentInfo[symbol] || {}
         return {
         symbol,
@@ -116,10 +105,10 @@ export class DividendCalculator {
         description: d.description,
         grossAmount,
         withheldTax,
-        netAmount:   grossAmount - withheldTax,
+        netAmount:   grossAmount.minus(withheldTax),
         country:     info.country     || '',
         countryName: info.countryName || '',
-        taxCode:     withheldTax > 0 ? 1 : 3,
+        taxCode:     withheldTax.gt(D0) ? 1 : 3,
         }
     })
     }

--- a/src/domain/tax/HoldingsCalculator.js
+++ b/src/domain/tax/HoldingsCalculator.js
@@ -1,6 +1,7 @@
 // HoldingsCalculator.js
 import { expandByAliases } from '../parser/parseInstruments.js'
 import { buildOpenPositions } from '../parser/parseOpenPositions.js'
+import { toDecimal, D0 } from '../numStr.js'
 
 export class HoldingsCalculator {
   constructor({ instrumentInfo }) {
@@ -39,9 +40,9 @@ export class HoldingsCalculator {
         Object.entries(positions).map(([sym, pos]) => [
           sym,
           {
-            cost: pos.cost.toNumber(),
-            qty: pos.qty.toNumber(),
-            costLcl: pos.costLcl.toNumber(),
+            cost: pos.cost,
+            qty: pos.qty,
+            costLcl: pos.costLcl,
           },
         ])
       ),
@@ -71,8 +72,9 @@ export class HoldingsCalculator {
 
     const acquDate = lastBuyDateExpanded[h.symbol] ?? null
 
-    const costPerShare = h.quantity ? h.costBasis / h.quantity : 0
-    const cost = Math.round(h.quantity * costPerShare * 100) / 100
+    const costBasis = h.costBasis != null
+      ? h.costBasis.toDecimalPlaces(2)
+      : D0
 
     return {
       symbol: h.symbol,
@@ -81,7 +83,7 @@ export class HoldingsCalculator {
       description: info.description ?? '',
       quantity: h.quantity,
       acquDate,
-      costBasis: cost,
+      costBasis,
       currency: h.currency,
       costLcl: positionsCostBasis[h.symbol]?.costLcl ?? null,
     }
@@ -113,10 +115,9 @@ export class HoldingsCalculator {
     const net = {}
 
     for (const t of trades) {
-      const q = Number(t.quantity) || 0
-
-      if (t.side === 'BUY') net[t.symbol] = (net[t.symbol] ?? 0) + q
-      if (t.side === 'SELL') net[t.symbol] = (net[t.symbol] ?? 0) - q
+      const q = toDecimal(t.quantity)
+      if (t.side === 'BUY')  net[t.symbol] = (net[t.symbol] ?? D0).plus(q)
+      if (t.side === 'SELL') net[t.symbol] = (net[t.symbol] ?? D0).minus(q)
     }
 
     return net

--- a/src/domain/tax/InterestCalculator.js
+++ b/src/domain/tax/InterestCalculator.js
@@ -1,12 +1,6 @@
 // InterestCalculator.js
 import { toLocalCurrency } from '../fx/fxRates.js'
-import Decimal from 'decimal.js'
-
-function toD(v) {
-  if (v instanceof Decimal) return v
-  const s = String(v ?? 0).replace(/,/g, '').trim()
-  try { return new Decimal(s) } catch { return new Decimal(0) }
-}
+import { toDecimal, D0 } from '../numStr.js'
 
 export class InterestCalculator {
   constructor({ context }) {
@@ -24,7 +18,7 @@ export class InterestCalculator {
 
   #mapRows(interest) {
     return interest.map(r => {
-      const amount = toD(r.amount)
+      const amount = toDecimal(r.amount)
 
       const amountLcl =
         toLocalCurrency(
@@ -32,7 +26,7 @@ export class InterestCalculator {
           r.currency,
           r.date,
           this.ctx.taxYear
-        ) ?? new Decimal(0)
+        ) ?? D0
 
       return {
         ...r,
@@ -57,8 +51,8 @@ export class InterestCalculator {
       result.push({
         _total: true,
         currency,
-        amount: subset.reduce((s, r) => s.plus(r.amount), new Decimal(0)),
-        amountLcl: subset.reduce((s, r) => s.plus(r.amountLcl), new Decimal(0)),
+        amount: subset.reduce((s, r) => s.plus(r.amount), D0),
+        amountLcl: subset.reduce((s, r) => s.plus(r.amountLcl), D0),
       })
     }
 
@@ -66,7 +60,7 @@ export class InterestCalculator {
     result.push({
       _total: true,
       currency: this.ctx.localCurrencyCode,
-      amountLcl: rows.reduce((s, r) => s.plus(r.amountLcl), new Decimal(0)),
+      amountLcl: rows.reduce((s, r) => s.plus(r.amountLcl), D0),
     })
 
     return result

--- a/src/domain/tax/TradeCalculator.js
+++ b/src/domain/tax/TradeCalculator.js
@@ -3,7 +3,7 @@ import Decimal from 'decimal.js'
 import { toLocalCurrency } from '../fx/fxRates.js'
 import { IBKR_EXCHANGES } from '../constants.js'
 import { isTaxable } from '../instrument/classifier.js'
-import { parseToDecimal, D0 } from '../numStr.js'
+import { toDecimal, D0 } from '../numStr.js'
 import { createCostBasisStrategy } from './costBasis/createCostBasisStrategy.js'
 
 function makeInstrument(trade, instrumentInfo) {
@@ -88,9 +88,9 @@ export class TradeCalculator {
     for (const p of priorPositions) {
       if (!p.symbol) continue
       map[p.symbol] = {
-        qty: new Decimal(p.qty),
-        cost: new Decimal(p.costUSD),
-        costLcl: new Decimal(p.costLcl),
+        qty: toDecimal(p.qty),
+        cost: toDecimal(p.costUSD),
+        costLcl: toDecimal(p.costLcl),
       }
     }
 
@@ -112,10 +112,10 @@ export class TradeCalculator {
     const instr = makeInstrument(t, this.instrumentInfo)
     const exempt = t.side === 'SELL' && !isTaxable(instr)
 
-    const proceedsD = parseToDecimal(t.proceeds) ?? D0
-    const commD     = parseToDecimal(t.commission) ?? D0
-    const feeD      = parseToDecimal(t.fee) ?? D0
-    const qtyD      = parseToDecimal(t.quantity).abs()
+    const proceedsD = toDecimal(t.proceeds)
+    const commD     = toDecimal(t.commission)
+    const feeD      = toDecimal(t.fee)
+    const qtyD      = toDecimal(t.quantity).abs()
 
     const totalD = proceedsD.plus(commD).plus(feeD)
     const totalLclD = this.#toLcl(totalD, t.currency, date)
@@ -163,7 +163,7 @@ export class TradeCalculator {
       currency: t.currency,
       side: t.side,
       quantity: qtyD,
-      price: parseToDecimal(t.price),
+      price: toDecimal(t.price),
 
       proceeds: proceedsD,
       commission: commD,

--- a/src/domain/tradeSummary.js
+++ b/src/domain/tradeSummary.js
@@ -2,31 +2,38 @@
  * Reactive trade summaries — recomputed whenever the user toggles taxable status.
  * Both functions are pure and operate on the current trade data rows from App state.
  */
+import Decimal from 'decimal.js'
 import { t } from '../localization/i18n.js'
+import { D0 } from './numStr.js'
 
-const TRADE_SUM_COLS     = ['proceeds', 'commission', 'fee', 'totalWithFee']
-const TRADE_SUM_LCL_COLS = ['totalWithFeeLcl', 'costBasisLcl']
+const TRADE_SUM_COLS     = ['proceeds', 'commission', 'fee', 'total']
+const TRADE_SUM_LCL_COLS = ['totalLcl', 'costBasisLcl']
 
 /**
  * Build per-group, per-currency total rows for the trades table.
- * Groups by taxExemptLabel ('Облагаем' / 'Освободен'), then by currency,
+ * Groups by taxable boolean (true = taxable, false = exempt), then by currency,
  * plus a local-currency grand total per group.
  */
 export function buildTradeTotals(dataRows, localCurrencyCode) {
   const totals = []
-  for (const label of [t('app.taxStatus.taxable'), t('app.taxStatus.exempt')]) {
-    const group = dataRows.filter(r => r.taxExemptLabel === label)
+  const groups = [
+    { taxable: true,  label: t('app.taxStatus.taxable') },
+    { taxable: false, label: t('app.taxStatus.exempt') },
+  ]
+
+  for (const { taxable, label } of groups) {
+    const group = dataRows.filter(r => r.taxable === taxable)
     if (group.length === 0) continue
     for (const cur of ['EUR', 'USD']) {
       const subset = group.filter(r => r.currency === cur)
       if (subset.length === 0) continue
       const row = { _total: true, taxExemptLabel: label, currency: cur }
-      TRADE_SUM_COLS.forEach(k    => { row[k] = subset.reduce((s, r) => s + (r[k] ?? 0), 0) })
-      TRADE_SUM_LCL_COLS.forEach(k => { row[k] = subset.reduce((s, r) => s + (r[k] ?? 0), 0) })
+      TRADE_SUM_COLS.forEach(k    => { row[k] = subset.reduce((s, r) => s.plus(r[k] ?? D0), D0) })
+      TRADE_SUM_LCL_COLS.forEach(k => { row[k] = subset.reduce((s, r) => s.plus(r[k] ?? D0), D0) })
       totals.push(row)
     }
     const lclRow = { _total: true, taxExemptLabel: label, currency: localCurrencyCode }
-    TRADE_SUM_LCL_COLS.forEach(k => { lclRow[k] = group.reduce((s, r) => s + (r[k] ?? 0), 0) })
+    TRADE_SUM_LCL_COLS.forEach(k => { lclRow[k] = group.reduce((s, r) => s.plus(r[k] ?? D0), D0) })
     totals.push(lclRow)
   }
   return totals
@@ -43,16 +50,16 @@ export function buildTaxSummary(dataRows) {
 
   const summarize = group => {
     const profits = group.reduce((s, r) => {
-      const pl = (r.totalWithFeeLcl ?? 0) - (r.costBasisLcl ?? 0)
-      return pl > 0 ? s + pl : s
-    }, 0)
+      const pl = (r.totalLcl ?? D0).minus(r.costBasisLcl ?? D0)
+      return pl.gt(D0) ? s.plus(pl) : s
+    }, D0)
     const losses = group.reduce((s, r) => {
-      const pl = (r.totalWithFeeLcl ?? 0) - (r.costBasisLcl ?? 0)
-      return pl < 0 ? s + Math.abs(pl) : s
-    }, 0)
+      const pl = (r.totalLcl ?? D0).minus(r.costBasisLcl ?? D0)
+      return pl.lt(D0) ? s.plus(pl.abs()) : s
+    }, D0)
     return {
-      totalProceedsLcl:  group.reduce((s, r) => s + (r.totalWithFeeLcl ?? 0), 0),
-      totalCostBasisLcl: group.reduce((s, r) => s + (r.costBasisLcl    ?? 0), 0),
+      totalProceedsLcl:  group.reduce((s, r) => s.plus(r.totalLcl    ?? D0), D0),
+      totalCostBasisLcl: group.reduce((s, r) => s.plus(r.costBasisLcl ?? D0), D0),
       profits,
       losses,
     }

--- a/src/presentation/DividendPresenter.js
+++ b/src/presentation/DividendPresenter.js
@@ -1,9 +1,12 @@
 // DividendPresenter.js
 import { t } from '../localization/i18n.js'
+import { fmt } from './fmt.js'
+import { decimalToNumber } from '../domain/numStr.js'
 
 export class DividendPresenter {
-  constructor({ lcl }) {
+  constructor({ lcl, mode = 'display' }) {
     this.lcl = lcl
+    this.mode = mode
   }
 
   buildDividendsTable(rows) {
@@ -19,7 +22,26 @@ export class DividendPresenter {
         { key: 'allowableCreditLcl', label: t('dividendTableCols.allowableCreditLcl'), shortLabel: t('dividendTableCols.allowableCreditLclShort', { lcl: this.lcl }), align: 'right', mono: true, decimals: 2, nullAs: '—' },
         { key: 'dueTaxLcl',          label: t('dividendTableCols.dueTaxLcl'), shortLabel: t('dividendTableCols.dueTaxLclShort', { lcl: this.lcl }), align: 'right', mono: true, decimals: 2, nullAs: '—' },
       ],
-      rows,
+      rows: this.#mapRows(rows),
     }
+  }
+
+  // -------------------------
+
+  #fmtNum(decimal, decimals) {
+    if (decimal == null) return null
+    return this.mode === 'display'
+      ? fmt(decimal, decimals)
+      : decimalToNumber(decimal)
+  }
+
+  #mapRows(rows) {
+    return rows.map(r => ({
+      ...r,
+      grossAmountLcl:     this.#fmtNum(r.grossAmountLcl, 2),
+      foreignTaxPaidLcl:  this.#fmtNum(r.foreignTaxPaidLcl, 2),
+      allowableCreditLcl: this.#fmtNum(r.allowableCreditLcl, 2),
+      dueTaxLcl:          this.#fmtNum(r.dueTaxLcl, 2),
+    }))
   }
 }

--- a/src/presentation/ExcelPresenter.js
+++ b/src/presentation/ExcelPresenter.js
@@ -29,28 +29,28 @@ export class ExcelPresenter {
     const { t, lcl } = this
     const sections = []
 
-    const tradePresenter = new TradePresenter({ lcl })
+    const tradePresenter = new TradePresenter({ lcl, mode: 'export' })
     const trades = tradePresenter.buildTable(result.trades)
     sections.push(buildSection(t('app.tabs.trades'), trades.columns, trades.rows))
 
-    const holdingPresenter = new HoldingPresenter({ lcl })
+    const holdingPresenter = new HoldingPresenter({ lcl, mode: 'export' })
     const holdings = holdingPresenter.buildHoldings(result.holdings)
     sections.push(buildSection(t('app.tabs.positions'), holdings.columns, holdings.rows))
 
     if (result.dividends.length > 0) {
-      const divPresenter = new DividendPresenter({ lcl })
+      const divPresenter = new DividendPresenter({ lcl, mode: 'export' })
       const dividends = divPresenter.buildDividendsTable(result.dividends)
       sections.push(buildSection(t('app.tabs.dividends'), dividends.columns, dividends.rows))
     }
 
     const realInterest = result.interest.filter(r => !r._total)
     if (realInterest.length > 0) {
-      const intPresenter = new InterestPresenter({ lcl })
+      const intPresenter = new InterestPresenter({ lcl, mode: 'export' })
       const interest = intPresenter.buildTable(result.interest)
       sections.push(buildSection(t('app.tabs.interest'), interest.columns, interest.rows))
     }
 
-    const summaryPresenter = new TradeSummaryPresenter({ t, lcl })
+    const summaryPresenter = new TradeSummaryPresenter({ t, lcl, mode: 'export' })
     sections.push(this.#summarySection(result.taxSummary, summaryPresenter))
 
     return sections.join('\n\n\n')

--- a/src/presentation/HoldingPresenter.js
+++ b/src/presentation/HoldingPresenter.js
@@ -1,9 +1,12 @@
 // HoldingsPresenter.js
 import { t } from '../localization/i18n.js'
+import { fmt } from './fmt.js'
+import { decimalToNumber } from '../domain/numStr.js'
 
 export class HoldingPresenter {
-  constructor({ lcl }) {
+  constructor({ lcl, mode = 'display' }) {
     this.lcl = lcl
+    this.mode = mode
   }
 
   buildHoldings(rows) {
@@ -32,6 +35,13 @@ export class HoldingPresenter {
   // -------------------------
   // PRIVATE
   // -------------------------
+
+  #fmtNum(decimal, decimals) {
+    if (decimal == null) return null
+    return this.mode === 'display'
+      ? fmt(decimal, decimals)
+      : decimalToNumber(decimal)
+  }
 
   #columns() {
     return [
@@ -72,6 +82,9 @@ export class HoldingPresenter {
       acquDate: r.acquDate
         ? r.acquDate.split('-').reverse().join('.')
         : null,
+      costBasis: this.#fmtNum(r.costBasis, 2),
+      costLcl:   this.#fmtNum(r.costLcl, 2),
+      quantity:  r.quantity != null ? decimalToNumber(r.quantity) : null,
     }))
   }
 }

--- a/src/presentation/InterestPresenter.js
+++ b/src/presentation/InterestPresenter.js
@@ -1,9 +1,12 @@
 // InterestPresenter.js
 import { t } from '../localization/i18n.js'
+import { fmt } from './fmt.js'
+import { decimalToNumber } from '../domain/numStr.js'
 
 export class InterestPresenter {
-  constructor({ lcl }) {
+  constructor({ lcl, mode = 'display' }) {
     this.lcl = lcl
+    this.mode = mode
   }
 
   buildTable(rows) {
@@ -14,6 +17,13 @@ export class InterestPresenter {
   }
 
   // -------------------------
+
+  #fmtNum(decimal, decimals) {
+    if (decimal == null) return null
+    return this.mode === 'display'
+      ? fmt(decimal, decimals)
+      : decimalToNumber(decimal)
+  }
 
   #buildColumns() {
     return [
@@ -35,8 +45,8 @@ export class InterestPresenter {
   #mapRows(rows) {
     return rows.map(r => ({
       ...r,
-      amount: r.amount?.toNumber?.() ?? null,
-      amountLcl: r.amountLcl?.toNumber?.() ?? null,
+      amount:    this.#fmtNum(r.amount, 2),
+      amountLcl: this.#fmtNum(r.amountLcl, 2),
       description: r._total ? t('interestTableCols.total') : r.description,
     }))
   }

--- a/src/presentation/TradePresenter.js
+++ b/src/presentation/TradePresenter.js
@@ -1,6 +1,8 @@
 // TradePresenter.js
 import { getInstrumentTypeLabel } from '../domain/instrument/classifier.js'
 import { t } from '../localization/i18n.js'
+import { fmt } from './fmt.js'
+import { decimalToNumber } from '../domain/numStr.js'
 
 const TRADE_COLUMNS = (lcl) => [
   { key: '#',               label: '#',                                  align: 'right', mono: true, decimals: 0 },
@@ -36,44 +38,13 @@ const TRADE_COLUMNS = (lcl) => [
 ]
 
 // -------------------------
-// helpers
-// -------------------------
-
-function toNumberSafe(v) {
-  if (v == null) return null
-  if (typeof v === 'number') return v
-  if (v?.toNumber) return v.toNumber()
-  return v
-}
-
-function toStringSafe(v) {
-  if (v == null) return null
-  if (typeof v === 'string') return v
-  if (v?.toString) return v.toString()
-  return String(v)
-}
-
-function normalizeRow(obj) {
-  const res = {}
-
-  for (const [k, v] of Object.entries(obj)) {
-    if (v?.toNumber) {
-      res[k] = v.toNumber()
-    } else {
-      res[k] = v
-    }
-  }
-
-  return res
-}
-
-// -------------------------
 // presenter
 // -------------------------
 
 export class TradePresenter {
-  constructor({ lcl }) {
+  constructor({ lcl, mode = 'display' }) {
     this.lcl = lcl
+    this.mode = mode
   }
 
   buildTable(rows) {
@@ -85,42 +56,45 @@ export class TradePresenter {
 
   // -------------------------
 
+  #fmtNum(decimal, decimals) {
+    if (decimal == null) return null
+    return this.mode === 'display'
+      ? fmt(decimal, decimals)
+      : decimalToNumber(decimal)
+  }
+
   #mapRows(rows) {
-    return rows.map(r => {
-      const mapped = {
-        ...r,
+    return rows.map(r => ({
+      ...r,
 
-        // UI-specific fields
-        '#': r.index,
+      // UI-specific fields
+      '#': r.index,
 
-        quantityDisplay: toStringSafe(r.quantity),
+      quantityDisplay: r.quantity?.toString() ?? null,
 
-        proceeds: toNumberSafe(r.proceeds),
-        commission: toNumberSafe(r.commission),
-        fee: toNumberSafe(r.fee),
+      proceeds:    this.#fmtNum(r.proceeds, 2),
+      commission:  this.#fmtNum(r.commission, 2),
+      fee:         this.#fmtNum(r.fee, 2),
 
-        totalWithFee: toNumberSafe(r.total),
-        totalWithFeeLcl: toNumberSafe(r.totalLcl),
-        rate: toNumberSafe(r.rate),
+      totalWithFee:    this.#fmtNum(r.total, 2),
+      totalWithFeeLcl: this.#fmtNum(r.totalLcl, 2),
+      rate:            this.#fmtNum(r.rate, 5),
 
-        costBasis: toNumberSafe(r.costBasis),
-        costBasisLcl: toNumberSafe(r.costBasisLcl),
+      costBasis:    this.#fmtNum(r.costBasis, 2),
+      costBasisLcl: this.#fmtNum(r.costBasisLcl, 2),
 
-        proceedsLcl: toNumberSafe(r.proceedsLcl),
-        realizedPLLcl: toNumberSafe(r.realizedPLLcl),
+      proceedsLcl:   this.#fmtNum(r.proceedsLcl, 2),
+      realizedPLLcl: this.#fmtNum(r.realizedPLLcl, 2),
 
-        instrType: getInstrumentTypeLabel({ type: r.instrType }),
+      instrType: r._total ? r.instrType : getInstrumentTypeLabel({ type: r.instrType }),
 
-        taxExemptLabel:
-          r.taxable == null
-            ? ''
-            : r.taxable
+      taxExemptLabel: r._total
+        ? r.taxExemptLabel
+        : r.taxable == null
+          ? ''
+          : r.taxable
             ? t('app.taxStatus.taxable')
             : t('app.taxStatus.exempt'),
-      }
-
-      // Final safety: ensure NO Decimal slips through
-      return normalizeRow(mapped)
-    })
+    }))
   }
 }

--- a/src/presentation/TradePresenter.js
+++ b/src/presentation/TradePresenter.js
@@ -72,6 +72,7 @@ export class TradePresenter {
 
       quantityDisplay: r.quantity?.toString() ?? null,
 
+      price:       this.#fmtNum(r.price, 4),
       proceeds:    this.#fmtNum(r.proceeds, 2),
       commission:  this.#fmtNum(r.commission, 2),
       fee:         this.#fmtNum(r.fee, 2),

--- a/src/presentation/TradeSummaryPresenter.js
+++ b/src/presentation/TradeSummaryPresenter.js
@@ -1,16 +1,13 @@
 // TradeSummaryPresenter.js
-
-function toNumberSafe(v) {
-  if (v == null) return 0
-  if (typeof v === 'number') return v
-  if (v?.toNumber) return v.toNumber()
-  return Number(v) || 0
-}
+import Decimal from 'decimal.js'
+import { fmt } from './fmt.js'
+import { toDecimal, decimalToNumber, D0 } from '../domain/numStr.js'
 
 export class TradeSummaryPresenter {
-  constructor({ t, lcl }) {
+  constructor({ t, lcl, mode = 'display' }) {
     this.t = t
     this.lcl = lcl
+    this.mode = mode
   }
 
   // -------------------------
@@ -19,12 +16,12 @@ export class TradeSummaryPresenter {
   buildTaxable(summary) {
     if (!summary) return null
 
-    const s = this.#normalize(summary)
+    const s = this.#toDecimal(summary)
 
-    const netTaxable = s.profits - s.losses
+    const netTaxable = s.profits.minus(s.losses)
     // чл. 33, ал. 3: 10% recognised expenses reduce the taxable base before the 10% rate
-    const taxableBase = Math.max(netTaxable, 0) * 0.90
-    const taxDue = taxableBase * 0.10
+    const taxableBase = Decimal.max(D0, netTaxable).times('0.90')
+    const taxDue = taxableBase.times('0.10')
 
     return {
       title: this.t('taxApp5.title'),
@@ -38,7 +35,7 @@ export class TradeSummaryPresenter {
         this.#row(
           this.t('taxApp5.netIncome', { lcl: this.lcl }),
           netTaxable,
-          netTaxable >= 0 ? 'success.main' : 'error.main'
+          netTaxable.gte(D0) ? 'success.main' : 'error.main'
         ),
         this.#row(this.t('taxApp5.taxableBase', { lcl: this.lcl }), taxableBase),
         this.#row(this.t('taxApp5.taxDue', { lcl: this.lcl }), taxDue, 'warning.dark'),
@@ -63,18 +60,18 @@ export class TradeSummaryPresenter {
   buildExempt(summary) {
     if (!summary) return null
 
-    const s = this.#normalize(summary)
+    const s = this.#toDecimal(summary)
 
     return {
       title: this.t('taxApp13.title'),
       subtitle: this.t('taxApp13.subtitle'),
 
-      rows: (s.totalProceedsLcl === 0) ? [] : (() => {
-        const result = s.totalProceedsLcl - s.totalCostBasisLcl
+      rows: s.totalProceedsLcl.isZero() ? [] : (() => {
+        const result = s.totalProceedsLcl.minus(s.totalCostBasisLcl)
         return [
           this.#row(this.t('taxApp13.grossIncome', { lcl: this.lcl }), s.totalProceedsLcl),
           this.#row(this.t('taxApp13.acquisitionCost', { lcl: this.lcl }), s.totalCostBasisLcl),
-          this.#row(this.t('taxApp13.result', { lcl: this.lcl }), result, result >= 0 ? 'success.main' : 'error.main'),
+          this.#row(this.t('taxApp13.result', { lcl: this.lcl }), result, result.gte(D0) ? 'success.main' : 'error.main'),
         ]
       })(),
     }
@@ -84,19 +81,26 @@ export class TradeSummaryPresenter {
   // PRIVATE
   // -------------------------
 
-  #normalize(summary) {
+  #toDecimal(summary) {
     return {
-      totalProceedsLcl: toNumberSafe(summary.totalProceedsLcl),
-      totalCostBasisLcl: toNumberSafe(summary.totalCostBasisLcl),
-      profits: toNumberSafe(summary.profits),
-      losses: toNumberSafe(summary.losses),
+      totalProceedsLcl:  toDecimal(summary.totalProceedsLcl),
+      totalCostBasisLcl: toDecimal(summary.totalCostBasisLcl),
+      profits:           toDecimal(summary.profits),
+      losses:            toDecimal(summary.losses),
     }
+  }
+
+  #fmtNum(decimal, decimals) {
+    if (decimal == null) return null
+    return this.mode === 'display'
+      ? fmt(decimal, decimals)
+      : decimalToNumber(decimal)
   }
 
   #row(label, value, color) {
     return {
       label,
-      value,
+      value: this.#fmtNum(value, 2),
       color,
     }
   }

--- a/src/ui/ResultTabs/TaxFormSection.jsx
+++ b/src/ui/ResultTabs/TaxFormSection.jsx
@@ -1,7 +1,6 @@
 import { Box, Paper, Typography } from '@mui/material'
 import { alpha } from '@mui/material/styles'
 import { ArticleOutlined } from '@mui/icons-material'
-import { fmt } from '../../presentation/fmt.js'
 
 export function TaxFormSection({ title, subtitle, rows }) {
   return (
@@ -37,7 +36,7 @@ export function TaxFormSection({ title, subtitle, rows }) {
           <TaxRow
             key={i}
             label={r.label}
-            value={fmt(r.value)}
+            value={r.value ?? '—'}
             color={r.color}
           />
         ))}</Box>

--- a/src/ui/ResultTabs/TaxableToggleDialog.jsx
+++ b/src/ui/ResultTabs/TaxableToggleDialog.jsx
@@ -6,6 +6,10 @@ export default function TaxableToggleDialog({ pending, onClose, onConfirm }) {
 
   if (!pending) return null
 
+  const currentLabel = pending.row.taxable
+    ? t('app.taxStatus.taxable')
+    : t('app.taxStatus.exempt')
+
   return (
     <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
       <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between' }}>
@@ -17,11 +21,11 @@ export default function TaxableToggleDialog({ pending, onClose, onConfirm }) {
 
       <DialogContent>
         <Typography variant="body2">
-          <strong>{pending.row.symbol}</strong> · {pending.row.dateTime}
+          <strong>{pending.row.symbol}</strong> · {pending.row.datetime}
         </Typography>
 
         <Typography variant="body2">
-          {pending.row.taxExemptLabel} → <strong>{pending.newLabel}</strong>
+          {currentLabel} → <strong>{pending.newLabel}</strong>
         </Typography>
       </DialogContent>
 

--- a/src/ui/ResultTabs/TradesTab.jsx
+++ b/src/ui/ResultTabs/TradesTab.jsx
@@ -14,34 +14,46 @@ import { TradePresenter } from '../../presentation/TradePresenter.js'
 export default function TradesTab({ result }) {
 
   const { taxYear, localCurrencyCode, localCurrencyLabel } = result
-  
-  
-  const tradePresenter = new TradePresenter({
-    lcl: localCurrencyLabel,
-  })
 
-  const tradesTable = tradePresenter.buildTable(result.trades)
+  const tradePresenter = new TradePresenter({ lcl: localCurrencyLabel })
 
-  const [rows, setRows] = useState(
-    tradesTable.rows.filter(r => !r._total)
+  // Raw Decimal rows (no _total rows); updated when user toggles taxable status
+  const [rawRows, setRawRows] = useState(
+    () => result.trades.filter(r => !r._total)
+  )
+
+  // Presented display rows (Decimal → locale strings)
+  const displayRows = useMemo(
+    () => tradePresenter.buildTable(rawRows).rows,
+    [rawRows]
+  )
+
+  // Domain totals (Decimal sums) then presented
+  const totalRows = useMemo(
+    () => buildTradeTotals(rawRows, localCurrencyCode),
+    [rawRows, localCurrencyCode]
+  )
+  const displayTotals = useMemo(
+    () => tradePresenter.buildTable(totalRows).rows,
+    [totalRows]
   )
 
   const trades = useMemo(() => ({
-    columns: tradesTable.columns,
-    rows: [...rows, ...buildTradeTotals(rows, localCurrencyCode)],
-  }), [rows, localCurrencyCode])
+    columns: tradePresenter.buildTable([]).columns,
+    rows: [...displayRows, ...displayTotals],
+  }), [displayRows, displayTotals])
 
-  const taxSummary = useMemo(() => buildTaxSummary(rows), [rows])
+  const taxSummary = useMemo(() => buildTaxSummary(rawRows), [rawRows])
 
   const approxRows = useMemo(
-    () => rows.filter(r => r.side === 'SELL' && r.costBasisLclApprox),
-    [rows]
+    () => rawRows.filter(r => r.side === 'SELL' && r.costBasisLclApprox),
+    [rawRows]
   )
 
   const [pending, setPending] = useState(null)
 
   function handleToggle(idx, _colKey) {
-    const row = rows[idx]
+    const row = rawRows[idx]
     if (row.taxable === null) return
 
     const newTaxable = !row.taxable
@@ -56,14 +68,10 @@ export default function TradesTab({ result }) {
   function confirm() {
     if (!pending) return
 
-    setRows(prev =>
+    setRawRows(prev =>
       prev.map((r, i) =>
         i === pending.idx
-          ? {
-              ...r,
-              taxable: pending.newTaxable,
-              taxExemptLabel: pending.newLabel,
-            }
+          ? { ...r, taxable: pending.newTaxable }
           : r
       )
     )
@@ -71,9 +79,9 @@ export default function TradesTab({ result }) {
     setPending(null)
   }
 
-  // ✅ always derive fresh row from current state
+  // always derive fresh row from current state
   const pendingWithRow = pending
-    ? { ...pending, row: rows[pending.idx] }
+    ? { ...pending, row: rawRows[pending.idx] }
     : null
 
   return (

--- a/src/ui/ThresholdWarning.jsx
+++ b/src/ui/ThresholdWarning.jsx
@@ -17,7 +17,7 @@ function fmtNum(n) {
 
 export default function ThresholdWarning({ holdings, localCurrencyLabel, localCurrencyCode }) {
 
-  const totalLcl = holdings.reduce((sum, h) => sum + (h.costLcl ?? 0), 0)
+  const totalLcl = holdings.reduce((sum, h) => sum + Number(h.costLcl ?? 0), 0)
   if (totalToEur(totalLcl, localCurrencyCode) <= SPB8_THRESHOLD_EUR) return null
 
   const details = t('spb8Warning.details', { returnObjects: true })

--- a/src/ui/ThresholdWarning.jsx
+++ b/src/ui/ThresholdWarning.jsx
@@ -1,14 +1,16 @@
+import Decimal from 'decimal.js'
 import { t } from '../localization/i18n.js'
 import { Box, Typography } from '@mui/material'
 import { alpha } from '@mui/material/styles'
 import { WarningAmberOutlined } from '@mui/icons-material'
+import { toDecimal, D0 } from '../domain/numStr.js'
 
-const EUR_BGN = 1.95583
-const SPB8_THRESHOLD_EUR = 25000
+const EUR_BGN = new Decimal('1.95583')
+const SPB8_THRESHOLD_EUR = new Decimal(25000)
 
 function totalToEur(totalLcl, localCurrencyCode) {
   if (localCurrencyCode === 'EUR') return totalLcl
-  return totalLcl / EUR_BGN
+  return totalLcl.div(EUR_BGN)
 }
 
 function fmtNum(n) {
@@ -17,8 +19,8 @@ function fmtNum(n) {
 
 export default function ThresholdWarning({ holdings, localCurrencyLabel, localCurrencyCode }) {
 
-  const totalLcl = holdings.reduce((sum, h) => sum + Number(h.costLcl ?? 0), 0)
-  if (totalToEur(totalLcl, localCurrencyCode) <= SPB8_THRESHOLD_EUR) return null
+  const totalLcl = holdings.reduce((sum, h) => sum.plus(toDecimal(h.costLcl ?? D0)), D0)
+  if (totalToEur(totalLcl, localCurrencyCode).lte(SPB8_THRESHOLD_EUR)) return null
 
   const details = t('spb8Warning.details', { returnObjects: true })
 


### PR DESCRIPTION
All domain parsers now return Decimal for numeric fields instead of raw
strings. buildOpenPositions uses Decimal arithmetic (removes parseNum).
numStr.js gains toDecimal, decimalToNumber, and decimalJsonReplacer helpers.

https://claude.ai/code/session_01HZfxMVgZPjhyoksZ1umFup