### PR TITLE
fix(#96): make hint text below dropzone a clickable link opening info modal

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,7 +1,6 @@
 import { t } from './localization/i18n.js'
 import { ThemeProvider, CssBaseline } from '@mui/material'
 import { Box, Button, Checkbox, FormControlLabel, Typography, Link, Alert } from '@mui/material'
-import { InfoOutlined } from '@mui/icons-material'
 
 import { dayTheme, nightTheme } from './theme.js'
 import { useTaxAppController } from './hooks/useTaxAppController.js'
@@ -53,12 +52,8 @@ export default function App() {
                   label={t('dropzone.csvLabel')}
                   infoKey="csv"
                   fileType={csvFile ? 'CSV' : undefined}
+                  hint={t('app.csvHint')}
                 />
-                <Typography variant="caption" color="text.secondary"
-                  sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: -1, mb: 1.5, px: 0.5 }}>
-                  <InfoOutlined sx={{ fontSize: 13 }} />
-                  {t('app.csvHint')}
-                </Typography>
               </Box>
               <Box>
                 <Dropzone
@@ -68,12 +63,8 @@ export default function App() {
                   label={t('dropzone.htmlLabel')}
                   infoKey="htm"
                   fileType={htmlFile ? 'HTML' : undefined}
+                  hint={t('app.htmlHint')}
                 />
-                <Typography variant="caption" color="text.secondary"
-                  sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: -1, mb: 1.5, px: 0.5 }}>
-                  <InfoOutlined sx={{ fontSize: 13 }} />
-                  {t('app.htmlHint')}
-                </Typography>
               </Box>
             </Box>
 

--- a/src/app/ui/Dropzone.jsx
+++ b/src/app/ui/Dropzone.jsx
@@ -12,6 +12,7 @@ export default function Dropzone({
   showInfo: showInfoProp = true,
   infoKey = 'csv',
   fileType,
+  hint,
 }) {
   const [showInfo, setShowInfo] = useState(false)
   const inputRef = useRef(null)
@@ -82,6 +83,20 @@ export default function Dropzone({
           </Box>
         )}
       </Box>
+
+      {hint && showInfoProp && (
+        <Link
+          component="button"
+          variant="caption"
+          color="text.secondary"
+          underline="hover"
+          onClick={() => setShowInfo(true)}
+          sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: -1, mb: 1.5, px: 0.5 }}
+        >
+          <InfoOutlined sx={{ fontSize: 13 }} />
+          {hint}
+        </Link>
+      )}
 
       {showInfoProp && (
         <Dialog open={showInfo} onClose={() => setShowInfo(false)} maxWidth="sm" fullWidth>


### PR DESCRIPTION
Adds a `hint` prop to Dropzone; when provided it renders below the
dropzone box as a MUI Link button (caption style) that opens the
existing info dialog. App.jsx passes the CSV/HTML hints via this prop
and removes the old non-interactive Typography blocks.

https://claude.ai/code/session_01A84rmq6yW5xAbQ83jttuzM