### PR TITLE
fix: update import paths after parser and numStr files were moved

### DIFF
--- a/src/app/hooks/useTaxAppController.js
+++ b/src/app/hooks/useTaxAppController.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { t } from '../localization/i18n.js'
 import { readInputFromFiles } from '../input/fileReader.js'
 import { calculateTax } from '@core/services/calculateTax.js'
-import { inferPriorPositions } from '@/core/services/inferPriorPositions.js'
+import { inferPriorPositions } from '@core/services/inferPriorPositions.js'
 import { useThemeMode } from './useThemeMode.js'
 import { decimalJsonReplacer } from '@util/numStr.js'
 

--- a/src/app/input/buildInputData.js
+++ b/src/app/input/buildInputData.js
@@ -12,14 +12,14 @@
  */
 
 import { parseCSV }                                        from './readCsv.js'
-import { parseTradesFromHtml }                             from '../parser/parseTradesHtml.js'
-import { parseStatementInfo }                              from '../parser/parseStatementInfo.js'
-import { parseInstruments }                                from '../parser/parseInstruments.js'
-import { parseDividends, parseWithholdingTax }             from '../parser/parseDividends.js'
-import { parseOpenPositions }                              from '../parser/parseOpenPositions.js'
-import { parseCsvTrades }                                  from '../parser/parseCsvTrades.js'
-import { parseInterest }                                   from '../parser/parseInterest.js'
-import { parseTaxYear }                                    from '../parser/parseTaxYear.js'
+import { parseTradesFromHtml }                             from './parser/parseTradesHtml.js'
+import { parseStatementInfo }                              from './parser/parseStatementInfo.js'
+import { parseInstruments }                                from './parser/parseInstruments.js'
+import { parseDividends, parseWithholdingTax }             from './parser/parseDividends.js'
+import { parseOpenPositions }                              from './parser/parseOpenPositions.js'
+import { parseCsvTrades }                                  from './parser/parseCsvTrades.js'
+import { parseInterest }                                   from './parser/parseInterest.js'
+import { parseTaxYear }                                    from './parser/parseTaxYear.js'
 import {
   validateCsvContent,
   validateHtmlContent,

--- a/src/app/input/parser/parseOpenPositions.js
+++ b/src/app/input/parser/parseOpenPositions.js
@@ -1,4 +1,4 @@
-import { getInstrumentTypeLabel } from '../instrument/classifier.js'
+import { getInstrumentTypeLabel } from '../../../core/domain/instrument/classifier.js'
 import { parseToDecimal, toDecimal } from '@util/numStr.js'
 
 /**

--- a/src/app/ui/ThresholdWarning.jsx
+++ b/src/app/ui/ThresholdWarning.jsx
@@ -3,7 +3,7 @@ import { t } from '../localization/i18n.js'
 import { Box, Typography } from '@mui/material'
 import { alpha } from '@mui/material/styles'
 import { WarningAmberOutlined } from '@mui/icons-material'
-import { toDecimal, D0 } from '../../core/domain/numStr.js'
+import { toDecimal, D0 } from '@util/numStr.js'
 
 const EUR_BGN = new Decimal('1.95583')
 const SPB8_THRESHOLD_EUR = new Decimal(25000)

--- a/src/app/ui/presentation/TradePresenter.js
+++ b/src/app/ui/presentation/TradePresenter.js
@@ -86,7 +86,7 @@ export class TradePresenter {
       proceedsLcl:   this.#fmtNum(r.proceedsLcl, 2),
       realizedPLLcl: this.#fmtNum(r.realizedPLLcl, 2),
 
-      instrType: r._total ? r.instrType : r.instrTypeLabel ),
+      instrType: r._total ? r.instrType : r.instrTypeLabel,
 
       taxExemptLabel: r._total
         ? t(`app.taxStatus.${r.taxExemptLabel.toLowerCase()}`)

--- a/src/core/domain/tax/HoldingsCalculator.js
+++ b/src/core/domain/tax/HoldingsCalculator.js
@@ -1,6 +1,6 @@
 // HoldingsCalculator.js
-import { expandByAliases } from '../parser/parseInstruments.js'
-import { buildOpenPositions } from '../parser/parseOpenPositions.js'
+import { expandByAliases } from '../../../app/input/parser/parseInstruments.js'
+import { buildOpenPositions } from '../../../app/input/parser/parseOpenPositions.js'
 import { toDecimal, D0 } from '@util/numStr.js'
 
 export class HoldingsCalculator {

--- a/src/core/services/__tests__/calculateTax.js
+++ b/src/core/services/__tests__/calculateTax.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import Decimal from 'decimal.js'
-import { calculateTax } from '../taxService.js'
+import { calculateTax } from '../calculateTax.js'
 
 import input from './fixtures/demoInput.json'
 import expected from './fixtures/demoOutput.json'
@@ -84,7 +84,7 @@ describe('calculateTax', () => {
 // MOCKS
 // -------------------------
 
-vi.mock('../domain/parser/parseInstruments.js', () => ({
+vi.mock('../../app/input/parser/parseInstruments.js', () => ({
   buildInstrumentInfo: vi.fn(() => ({
     AAPL: {
       description: 'Apple Inc.',
@@ -96,7 +96,7 @@ vi.mock('../domain/parser/parseInstruments.js', () => ({
   })),
 }))
 
-vi.mock('../domain/parser/parseCsvTrades.js', () => ({
+vi.mock('../../app/input/parser/parseCsvTrades.js', () => ({
   buildCsvTradeBasis: vi.fn(() => new Map()),
 }))
 

--- a/src/core/services/calculateTax.js
+++ b/src/core/services/calculateTax.js
@@ -1,5 +1,5 @@
-import { buildInstrumentInfo } from '../domain/parser/parseInstruments.js'
-import { buildCsvTradeBasis } from '../domain/parser/parseCsvTrades.js'
+import { buildInstrumentInfo } from '../../app/input/parser/parseInstruments.js'
+import { buildCsvTradeBasis } from '../../app/input/parser/parseCsvTrades.js'
 import {
   getLocalCurrencyCode,
   getLocalCurrencyLabel,

--- a/src/core/services/inferPriorPositions.js
+++ b/src/core/services/inferPriorPositions.js
@@ -1,9 +1,9 @@
 import {
   toLocalCurrency, getPrevYearEndDate,
 } from '../domain/fx/fxRates.js'
-import { buildInstrumentInfo } from '../domain/parser/parseInstruments.js'
-import { buildCsvTradeBasis } from '../domain/parser/parseCsvTrades.js'
-import { parseTaxYear } from '../domain/parser/parseTaxYear.js'
+import { buildInstrumentInfo } from '../../app/input/parser/parseInstruments.js'
+import { buildCsvTradeBasis } from '../../app/input/parser/parseCsvTrades.js'
+import { parseTaxYear } from '../../app/input/parser/parseTaxYear.js'
 import { toDecimal, D0 } from '@util/numStr.js'
 
 /**


### PR DESCRIPTION
- buildInputData.js: ../parser/ → ./parser/ (parsers are now in same dir)
- parseOpenPositions.js: ../instrument/classifier.js → ../../../core/domain/instrument/classifier.js
- ThresholdWarning.jsx: ../../core/domain/numStr.js → @util/numStr.js
- HoldingsCalculator.js: ../parser/ → ../../../app/input/parser/
- calculateTax.js: ../domain/parser/ → ../../app/input/parser/
- inferPriorPositions.js: ../domain/parser/ → ../../app/input/parser/
- __tests__/calculateTax.js: ../taxService.js → ../calculateTax.js, mock paths updated

https://claude.ai/code/session_012CromquYW7bi7f3VRUnvjK