### PR TITLE
Update ARCHITECTURE.md to reflect parser/service refactor and file-layout changes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,8 +13,9 @@ No data leaves the browser.
 ```
 src/
   core/           Pure pipeline — no browser APIs, no React
-    services/     Use-case orchestration (calculateTax, inferPriorPositions)
-    domain/       Business logic (tax, FX, parsers)
+    services/     Use-case orchestration (calculateTax, parseInput)
+    parser/       Input normalization + inference (buildInputData, inferPriorPositions)
+    domain/       Business logic (tax, FX)
       tax/
         costBasis/  Cost-basis strategies
   app/            Everything React and browser-specific
@@ -50,18 +51,18 @@ portable and testable without a browser.
 User drops CSV + HTML files
         |
         v
-app/input/fileReader.js
-  readInputFromFiles({ csvFile, htmlFile })
+app/input/csvParser.js + app/input/htmlParser.js
+  parse raw files into csvText/htmlDoc
         |
         v
-app/input/parseInput.js
+core/services/parseInput.js
   parseInput({ csvText, htmlDoc })
         |
         v
-app/input/buildInputData.js
+core/parser/buildInputData.js
   parseActivityStatementCsv(csvText)   -- CSV rows
   parseTradeConfirmationHtml(htmlDoc)  -- Trade[]
-  buildInputData(csvRows, trades)       -- InputData
+  buildInputData(csvRows, trades)      -- InputData
         |
         v
 app/hooks/useTaxAppController.js
@@ -92,26 +93,21 @@ app/ui/ResultTabs/ (TradesTab, HoldingsTab, DividendsTab, InterestTab)
 
 ### `app/input/`
 
-The only layer that may use browser globals or read files. It converts raw
-browser inputs into plain data and hands off to `core/`.
+Browser-facing adapters for file parsing/validation before handing raw text to
+`core/` services.
 
-- `fileReader.js` — reads `File` objects, delegates to `parseInput`
+- `csvParser.js` — wraps PapaParse for CSV input
 - `htmlParser.js` — wraps `DOMParser`
-- `readCsv.js` — wraps PapaParse; returns `string[][]`
-- `parseInput.js` — thin entry-point: `parseInput({ csvText, htmlDoc })` → `InputData`
-- `buildInputData.js` — orchestrates domain parsers, returns canonical `InputData`
 - `validateInput.js` — validates IBKR file content before parsing
-- `themeStorage.js` — browser storage adapter for theme persistence (wraps
-  `localStorage` + `document.documentElement`; used only by `app/hooks/useThemeMode`)
 
 ### `core/services/`
 
 Thin use-case orchestrators. No business logic.
 
 - `calculateTax.js` — builds `TaxContext`, wires domain calculators, returns result
-- `inferPriorPositions.js` — detects sells with no matching buys in the statement
+- `parseInput.js` — parses CSV + HTML into canonical `InputData`
 
-### `core/domain/parser/`
+### `core/parser/`
 
 Parse specific CSV sections or HTML into plain objects.
 Inputs are raw strings or pre-parsed DOM nodes; outputs are typed arrays.
@@ -183,7 +179,7 @@ writes back to the result array held in the controller.
 
 ### `core/` has no browser dependencies
 
-All browser globals are confined to `app/input/`. `core/domain/parser/` receives
+All browser globals are confined to `app/input/`. `core/parser/` receives
 pre-parsed DOM nodes (passed in from `app/input/htmlParser.js`) rather than
 calling `DOMParser` itself. This keeps the entire `core/` tree runnable in Node.
 
@@ -227,7 +223,7 @@ Top-level components:
 ## Theming
 
 Two themes defined in `src/app/theme.js` (`dayTheme`, `nightTheme`).
-`useThemeMode` hook persists the choice via `app/input/themeStorage.js`,
+`useThemeMode` hook persists the choice via `app/hooks/themeStorage.js`,
 which writes `data-theme="day|night"` on `document.documentElement`.
 MUI theme is applied via `ThemeProvider`; `styles/index.css` uses `[data-theme]`
 selectors only for the non-MUI layout shell.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,10 +34,12 @@ src/
 ### Dependency direction
 
 ```
-app/ui/ResultTabs → app/ui/presentation ─────┐
-app/App.jsx       → app/hooks                │
-                       ├── core/services ─────┤→ core/domain
-                       └── app/input ─────────┘
+app/ui/ResultTabs → app/ui/presentation
+app/App.jsx       → app/hooks → app/input/fileReader
+                                  ├── app/input/{csvParser,htmlParser}
+                                  └── core/services/{parseInput,calculateTax}
+                                         ├── core/parser
+                                         └── core/domain
 ```
 
 `core/` has no imports from `app/` or `styles/`. This keeps the pipeline
@@ -51,8 +53,11 @@ portable and testable without a browser.
 User drops CSV + HTML files
         |
         v
-app/input/csvParser.js + app/input/htmlParser.js
-  parse raw files into csvText/htmlDoc
+app/input/fileReader.js
+  readInputFromFiles({ csvFile, htmlFile })
+        |
+        +-> app/input/csvParser.js
+        +-> app/input/htmlParser.js
         |
         v
 core/services/parseInput.js
@@ -96,6 +101,7 @@ app/ui/ResultTabs/ (TradesTab, HoldingsTab, DividendsTab, InterestTab)
 Browser-facing adapters for file parsing/validation before handing raw text to
 `core/` services.
 
+- `fileReader.js` — reads `File` objects and orchestrates CSV/HTML extraction
 - `csvParser.js` — wraps PapaParse for CSV input
 - `htmlParser.js` — wraps `DOMParser`
 - `validateInput.js` — validates IBKR file content before parsing

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,11 +35,12 @@ src/
 
 ```
 app/ui/ResultTabs → app/ui/presentation
-app/App.jsx       → app/hooks → app/input/fileReader
-                                  ├── app/input/{csvParser,htmlParser}
-                                  └── core/services/{parseInput,calculateTax}
-                                         ├── core/parser
-                                         └── core/domain
+app/App.jsx       → app/hooks
+                       ├── app/input/fileReader
+                       │     └── app/input/{csvParser,htmlParser}
+                       └── core/services/{parseInput,calculateTax}
+                              ├── core/parser
+                              └── core/domain
 ```
 
 `core/` has no imports from `app/` or `styles/`. This keeps the pipeline
@@ -60,8 +61,11 @@ app/input/fileReader.js
         +-> app/input/htmlParser.js
         |
         v
-core/services/parseInput.js
-  parseInput({ csvText, htmlDoc })
+Raw parsed payload ({ activityStatement, tradeConfirmation })
+        |
+        v
+app/hooks/useTaxAppController.js
+  parseInput(payload) via core/services/parseInput.js
         |
         v
 core/parser/buildInputData.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ React 19 + Vite SPA deployed to GitHub Pages. The app parses Interactive Brokers
 ```
 User selects CSV + HTML
         ↓
-useTaxAppController → readInputFromFiles() → parseInput() → inputData
+useTaxAppController → csvParser/htmlParser → parseInput() → inputData
         ↓
 inferPriorPositions() → pendingPositions
         ↓
@@ -86,12 +86,16 @@ Pure pipeline — no browser APIs, no React. Safe to run on a server.
 
 **`src/core/services/`** — use-case orchestration:
 
-* `inferPriorPositions`
+* `parseInput`
 * `calculateTax`
+
+**`src/core/parser/`** — parsing and input normalization:
+
+* input parsers — accept strings or pre-parsed DOM objects
+* `buildInputData` and `inferPriorPositions`
 
 **`src/core/domain/`** — business logic:
 
-* parsers (`parser/`) — accept strings or pre-parsed DOM objects
 * tax calculators (`tax/`) — `TradeCalculator`, `DividendCalculator`, `HoldingsCalculator`, `InterestCalculator`
 * cost-basis strategies (`tax/costBasis/`) — `WeightedAverageCostBasisStrategy` (BG-law default), `IbkrCostBasisStrategy` (uses CSV value, falls back to weighted-average); `createCostBasisStrategy(name)` factory
 * FX utilities (`fx/`)
@@ -102,17 +106,10 @@ No React imports. No browser globals. No localization calls (`t` is forbidden in
 
 ### Input layer (`src/app/input/`)
 
-File I/O and input assembly — the only place that reads browser File/DOM objects and turns them into domain data. The orchestrator reads input and passes it to core.
+Browser adapters for parsing/validation before passing raw text/DOM into core.
 
-* `fileReader.js` — reads File objects, calls `parseInput`
+* `csvParser.js` — wraps PapaParse
 * `htmlParser.js` — wraps `DOMParser`
-* `themeStorage.js` — browser storage adapter for theme persistence (used only by `app/hooks/useThemeMode`)
-* `readCsv.js` — wraps PapaParse; accepts CSV text, returns `string[][]`
-* `parseInput.js` — thin entry-point: `parseInput({ csvText, htmlDoc })` → InputData
-* `buildInputData.js` — format detection, validation, InputData assembly:
-  * `parseActivityStatementCsv(csvText)`
-  * `parseTradeConfirmationHtml(doc)` — accepts pre-parsed Document
-  * `buildInputData(csvRows, trades)`
 * `validateInput.js` — validates IBKR file content
 
 ---
@@ -158,7 +155,7 @@ Themes defined in `src/app/theme.js`:
 * `dayTheme`
 * `nightTheme`
 
-Applied via `useThemeMode` hook → `app/input/themeStorage.js`:
+Applied via `useThemeMode` hook → `app/hooks/themeStorage.js`:
 
 ```js
 document.documentElement.setAttribute('data-theme', 'night' | 'day')
@@ -247,8 +244,9 @@ Do not hardcode colors.
 ```
 src/
   core/          ← pure pipeline (server-exportable, no browser APIs, no React)
-    services/    ← use-case orchestration (calculateTax, inferPriorPositions)
-    domain/      ← business logic (tax calculators, FX, parsers)
+    services/    ← use-case orchestration (calculateTax, parseInput)
+    parser/      ← input normalization + inference
+    domain/      ← business logic (tax calculators, FX)
       tax/costBasis/  ← cost-basis strategies (weighted-average, IBKR)
   app/           ← everything React and browser-specific
     App.jsx      ← composition shell

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ No React imports. No browser globals. No localization calls (`t` is forbidden in
 
 Browser adapters for parsing/validation before passing raw text/DOM into core.
 
+* `fileReader.js` — reads `File` objects and orchestrates CSV/HTML extraction
 * `csvParser.js` — wraps PapaParse
 * `htmlParser.js` — wraps `DOMParser`
 * `validateInput.js` — validates IBKR file content
@@ -140,10 +141,12 @@ No business logic. No direct browser API imports (except `presentation/` which i
 ### Dependency direction
 
 ```
-app/ui/ResultTabs → app/ui/presentation ─────┐
-app/App.jsx       → app/hooks                │
-                       ├── core/services ─────┤→ core/domain
-                       └── app/input ─────────┘
+app/ui/ResultTabs → app/ui/presentation
+app/App.jsx       → app/hooks → app/input/fileReader
+                                  ├── app/input/{csvParser,htmlParser}
+                                  └── core/services/{parseInput,calculateTax}
+                                         ├── core/parser
+                                         └── core/domain
 ```
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ React 19 + Vite SPA deployed to GitHub Pages. The app parses Interactive Brokers
 ```
 User selects CSV + HTML
         ↓
-useTaxAppController → csvParser/htmlParser → parseInput() → inputData
+useTaxAppController → fileReader(csvParser/htmlParser) → parseInput() → inputData
         ↓
 inferPriorPositions() → pendingPositions
         ↓
@@ -142,11 +142,12 @@ No business logic. No direct browser API imports (except `presentation/` which i
 
 ```
 app/ui/ResultTabs → app/ui/presentation
-app/App.jsx       → app/hooks → app/input/fileReader
-                                  ├── app/input/{csvParser,htmlParser}
-                                  └── core/services/{parseInput,calculateTax}
-                                         ├── core/parser
-                                         └── core/domain
+app/App.jsx       → app/hooks
+                       ├── app/input/fileReader
+                       │     └── app/input/{csvParser,htmlParser}
+                       └── core/services/{parseInput,calculateTax}
+                              ├── core/parser
+                              └── core/domain
 ```
 
 ---


### PR DESCRIPTION
### Motivation
- Document recent refactor that separates browser-facing file parsers from core parsing and clarifies service responsibilities.
- Make the `core/` vs `app/` boundaries and data-flow explicit after renaming and moving parsing-related modules.
- Reflect relocation of theme storage and other small path/name changes so the architecture doc matches the codebase.

### Description
- Update data-flow and layer diagrams to show `csvParser.js` and `htmlParser.js` as browser adapters in `app/input/` and to move `parseInput` into `core/services`.
- Rename/relocate parsing modules: `buildInputData` is now under `core/parser`, and the parser folder is renamed from `core/domain/parser/` to `core/parser/`.
- Adjust service names and callsites in the diagrams and prose to show `core/services/parseInput.js` and `core/services/calculateTax.js` as thin orchestrators.
- Update the `themeStorage` path reference from `app/input/themeStorage.js` to `app/hooks/themeStorage.js` and tidy several wording items to reflect the new structure.

### Testing
- Ran the existing Vitest suite against the codebase referenced by the documentation, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6021eadd8832b89cd44f0ef7aefaf)