### PR TITLE
Use ISIN-derived country for holdings and dividends

### DIFF
--- a/src/app/ui/presentation/DividendPresenter.js
+++ b/src/app/ui/presentation/DividendPresenter.js
@@ -36,12 +36,20 @@ export class DividendPresenter {
   }
 
   #mapRows(rows) {
-    return rows.map(r => ({
-      ...r,
-      grossAmountLcl:     this.#fmtNum(r.grossAmountLcl, 2),
-      foreignTaxPaidLcl:  this.#fmtNum(r.foreignTaxPaidLcl, 2),
-      allowableCreditLcl: this.#fmtNum(r.allowableCreditLcl, 2),
-      dueTaxLcl:          this.#fmtNum(r.dueTaxLcl, 2),
-    }))
+    return rows.map(r => {
+      const countryKey = `countryNames.${r.countryName}`
+      const countryDisplay = r.countryName
+        ? (t(countryKey) !== countryKey ? t(countryKey) : r.countryName)
+        : ''
+
+      return {
+        ...r,
+        countryName:       countryDisplay,
+        grossAmountLcl:     this.#fmtNum(r.grossAmountLcl, 2),
+        foreignTaxPaidLcl:  this.#fmtNum(r.foreignTaxPaidLcl, 2),
+        allowableCreditLcl: this.#fmtNum(r.allowableCreditLcl, 2),
+        dueTaxLcl:          this.#fmtNum(r.dueTaxLcl, 2),
+      }
+    })
   }
 }

--- a/src/core/domain/tax/DividendCalculator.js
+++ b/src/core/domain/tax/DividendCalculator.js
@@ -106,8 +106,8 @@ export class DividendCalculator {
         grossAmount,
         withheldTax,
         netAmount:   grossAmount.minus(withheldTax),
-        country:     info.country     || '',
-        countryName: info.countryName || '',
+        country:     info.country || '',
+        countryName: info.country || '',
         taxCode:     withheldTax.gt(D0) ? 1 : 3,
         }
     })

--- a/src/core/domain/tax/HoldingsCalculator.js
+++ b/src/core/domain/tax/HoldingsCalculator.js
@@ -79,7 +79,7 @@ export class HoldingsCalculator {
     return {
       symbol: h.symbol,
       type: info.type,          // raw, not localized
-      country: info.countryName || h.currency,
+      country: info.country || '',
       description: info.description ?? '',
       quantity: h.quantity,
       acquDate,


### PR DESCRIPTION
### Motivation
- Holdings and dividends tables should display country names derived from an instrument's ISIN prefix (first two characters) instead of falling back to currency or being empty. 
- The presenter should translate the ISIN country code into a localized country name with a safe fallback to the raw code.

### Description
- Use the ISIN-derived `info.country` for holdings rows by changing the `country` field in `HoldingsCalculator` to `info.country || ''` so open positions can resolve to countries correctly.
- Ensure dividend matching emits `country` and `countryName` from `info.country` in `DividendCalculator` so dividend rows carry the ISIN country code.
- Update `DividendPresenter` to translate `countryName` codes using `t('countryNames.<code>')` with a fallback to the raw code or empty string for display.
- This leverages the existing instrument info built from `securityId` (ISIN) which already extracts the country code from the ISIN prefix.

### Testing
- Ran `npm test -- --run src/core/parser/parsers/__tests__/parseOpenPositions.test.js src/core/services/__tests__/calculateTax.js` and the specified test targets passed. 
- All executed vitest assertions completed successfully without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6fcb70294832bb13be5cac432752c)